### PR TITLE
Use template-based tag dispatch

### DIFF
--- a/generate_vulkan_layer.py
+++ b/generate_vulkan_layer.py
@@ -402,28 +402,28 @@ def generate_layer_instance_dispatch_table(file, mapping, commands, style):
         tname = command.name
         if tname not in FORWARD_WITHOUT_INTERCEPT:
             if plat_define:
-                itable_members.append(f'#if defined({plat_define})\n')
+                itable_members.append(f'#if defined({plat_define})')
 
-            itable_members.append(f'   {{ "{tname}", reinterpret_cast<PFN_vkVoidFunction>(layer_{tname}<user_tag>) }},\n')
+            itable_members.append(f'   ENTRY({tname}),')
             if plat_define:
-                itable_members.append('#endif\n')
+                itable_members.append('#endif')
 
         if tname not in INTERCEPT_WITHOUT_FORWARD:
             if plat_define:
-                dispatch_table_members.append(f'#if defined({plat_define})\n')
-                dispatch_table_inits.append(f'#if defined({plat_define})\n')
+                dispatch_table_members.append(f'#if defined({plat_define})')
+                dispatch_table_inits.append(f'#if defined({plat_define})')
 
-            dispatch_table_members.append(f'    {ttype} {tname};\n')
-            dispatch_table_inits.append(f'    ENTRY({tname});\n')
+            dispatch_table_members.append(f'    {ttype} {tname};')
+            dispatch_table_inits.append(f'    ENTRY({tname});')
 
             if plat_define:
-                dispatch_table_members.append('#endif\n')
-                dispatch_table_inits.append('#endif\n')
+                dispatch_table_members.append('#endif')
+                dispatch_table_inits.append('#endif')
 
 
-    data = data.replace('{ITABLE_MEMBERS}', ''.join(itable_members))
-    data = data.replace('{DTABLE_MEMBERS}', ''.join(dispatch_table_members))
-    data = data.replace('{DTABLE_INITS}', ''.join(dispatch_table_inits))
+    data = data.replace('{ITABLE_MEMBERS}', '\n'.join(itable_members))
+    data = data.replace('{DTABLE_MEMBERS}', '\n'.join(dispatch_table_members))
+    data = data.replace('{DTABLE_INITS}', '\n'.join(dispatch_table_inits))
     file.write(data)
 
 
@@ -568,18 +568,18 @@ def generate_layer_device_dispatch_table(file, mapping, commands, style):
             dispatch_table_members.append(f'#if defined({plat_define})')
             dispatch_table_inits.append(f'#if defined({plat_define})')
 
-        itable_members.append(f'   {{ "{tname}", reinterpret_cast<PFN_vkVoidFunction>(layer_{tname}<user_tag>) }},\n')
-        dispatch_table_members.append(f'    {ttype} {tname};\n')
-        dispatch_table_inits.append(f'    ENTRY({tname});\n')
+        itable_members.append(f'    ENTRY({tname}),')
+        dispatch_table_members.append(f'    {ttype} {tname};')
+        dispatch_table_inits.append(f'    ENTRY({tname});')
 
         if plat_define:
             itable_members.append('#endif')
             dispatch_table_members.append('#endif')
             dispatch_table_inits.append('#endif')
 
-    data = data.replace('{ITABLE_MEMBERS}', ''.join(itable_members))
-    data = data.replace('{DTABLE_MEMBERS}', ''.join(dispatch_table_members))
-    data = data.replace('{DTABLE_INITS}', ''.join(dispatch_table_inits))
+    data = data.replace('{ITABLE_MEMBERS}', '\n'.join(itable_members))
+    data = data.replace('{DTABLE_MEMBERS}', '\n'.join(dispatch_table_members))
+    data = data.replace('{DTABLE_INITS}', '\n'.join(dispatch_table_inits))
     file.write(data)
 
 

--- a/generate_vulkan_layer.py
+++ b/generate_vulkan_layer.py
@@ -481,13 +481,13 @@ def generate_layer_instance_layer_decls(file, mapping, commands, style):
         retfwd = 'return ' if command.rtype != 'void' else ''
         lines.append(') {')
         lines.append(f'    {retfwd}layer_{command.name}_default({parmfwd});')
-        lines.append('}')
+        lines.append('}\n')
 
         if plat_define:
-            lines.append('\n#endif')
+            lines.append('#endif\n')
 
         file.write('\n'.join(lines))
-        file.write('\n\n')
+        file.write('\n')
 
 
 def generate_layer_instance_layer_defs(file, mapping, commands, manual_commands, style):
@@ -637,13 +637,13 @@ def generate_layer_device_layer_decls(file, mapping, commands, style):
         retfwd = 'return ' if command.rtype != 'void' else ''
         lines.append(') {')
         lines.append(f'    {retfwd}layer_{command.name}_default({parmfwd});')
-        lines.append('}')
+        lines.append('}\n')
 
         if plat_define:
-            lines.append('\n#endif')
+            lines.append('#endif\n')
 
         file.write('\n'.join(lines))
-        file.write('\n\n')
+        file.write('\n')
 
 
 def generate_layer_device_layer_defs(file, mapping, commands, manual_commands, style):

--- a/generate_vulkan_layer.py
+++ b/generate_vulkan_layer.py
@@ -404,7 +404,7 @@ def generate_layer_instance_dispatch_table(file, mapping, commands, style):
             if plat_define:
                 itable_members.append(f'#if defined({plat_define})\n')
 
-            itable_members.append(f'   {{ STR(fnc), reinterpret_cast<PFN_vkVoidFunction>(layer_{tname}<user_tag>) }},\n')
+            itable_members.append(f'   {{ "{tname}", reinterpret_cast<PFN_vkVoidFunction>(layer_{tname}<user_tag>) }},\n')
             if plat_define:
                 itable_members.append('#endif\n')
 
@@ -568,7 +568,7 @@ def generate_layer_device_dispatch_table(file, mapping, commands, style):
             dispatch_table_members.append(f'#if defined({plat_define})')
             dispatch_table_inits.append(f'#if defined({plat_define})')
 
-        itable_members.append(f'   {{ STR(fnc), reinterpret_cast<PFN_vkVoidFunction>(layer_{tname}<user_tag>) }},\n')
+        itable_members.append(f'   {{ "{tname}", reinterpret_cast<PFN_vkVoidFunction>(layer_{tname}<user_tag>) }},\n')
         dispatch_table_members.append(f'    {ttype} {tname};\n')
         dispatch_table_inits.append(f'    ENTRY({tname});\n')
 

--- a/generate_vulkan_layer.py
+++ b/generate_vulkan_layer.py
@@ -451,6 +451,7 @@ def generate_layer_instance_layer_decls(file, mapping, commands, style):
 
         # Declare the default implementation
         lines.append('/* See Vulkan API for documentation. */')
+        lines.append('/* Default common code pass-through implementation. */')
         decl = f'VKAPI_ATTR {command.rtype} VKAPI_CALL layer_{command.name}_default('
         lines.append(decl)
 
@@ -463,7 +464,7 @@ def generate_layer_instance_layer_decls(file, mapping, commands, style):
         lines.append('')
 
         # Define the default tag dispatch handler
-        lines.append('/* Default template without specialization. */')
+        lines.append('/* Match-all template to use default implementation. */')
         decl = 'template <typename T>'
         lines.append(decl)
         decl = f'VKAPI_ATTR {command.rtype} VKAPI_CALL layer_{command.name}('
@@ -606,6 +607,7 @@ def generate_layer_device_layer_decls(file, mapping, commands, style):
             lines.append(f'#if defined({plat_define})\n')
 
         lines.append('/* See Vulkan API for documentation. */')
+        lines.append('/* Default common code pass-through implementation. */')
         decl = f'VKAPI_ATTR {command.rtype} VKAPI_CALL layer_{command.name}_default('
         lines.append(decl)
 
@@ -618,7 +620,7 @@ def generate_layer_device_layer_decls(file, mapping, commands, style):
         lines.append('')
 
         # Define the default tag dispatch handler
-        lines.append('/* Default template without specialization. */')
+        lines.append('/* Match-all template to use default implementation. */')
         decl = 'template <typename T>'
         lines.append(decl)
         decl = f'VKAPI_ATTR {command.rtype} VKAPI_CALL layer_{command.name}('

--- a/templates/vulkan/codegen_forward/device_dispatch_table.txt
+++ b/templates/vulkan/codegen_forward/device_dispatch_table.txt
@@ -23,6 +23,8 @@ struct DeviceInterceptTableEntry
     PFN_vkVoidFunction function;
 };
 
+#define ENTRY(fnc) { STR(fnc), reinterpret_cast<PFN_vkVoidFunction>(layer_##fnc<user_tag>) }
+
 /**
  * \brief The device dispatch table used to call the driver.
  */

--- a/templates/vulkan/codegen_forward/device_dispatch_table.txt
+++ b/templates/vulkan/codegen_forward/device_dispatch_table.txt
@@ -29,7 +29,8 @@ struct DeviceInterceptTableEntry
  * \brief The device dispatch table used to call the driver.
  */
 static const struct DeviceInterceptTableEntry deviceIntercepts[] = {
-{ITABLE_MEMBERS}};
+{ITABLE_MEMBERS}
+};
 
 #undef ENTRY
 
@@ -37,7 +38,8 @@ static const struct DeviceInterceptTableEntry deviceIntercepts[] = {
 struct DeviceDispatchTable {
     PFN_vkGetDeviceProcAddr vkGetDeviceProcAddr;
 
-{DTABLE_MEMBERS}};
+{DTABLE_MEMBERS}
+};
 
 #define ENTRY(fnc) table.fnc = (PFN_##fnc)getProcAddr(device, STR(fnc))
 
@@ -55,6 +57,7 @@ static inline void initDriverDeviceDispatchTable(
 ) {
     table.vkGetDeviceProcAddr = getProcAddr;
 
-{DTABLE_INITS}}
+{DTABLE_INITS}
+}
 
 #undef ENTRY

--- a/templates/vulkan/codegen_forward/device_dispatch_table.txt
+++ b/templates/vulkan/codegen_forward/device_dispatch_table.txt
@@ -3,6 +3,9 @@
 #include <vulkan/vulkan.h>
 
 #include "device_functions.hpp"
+#if __has_include ("layer_device_functions.hpp")
+    #include "layer_device_functions.hpp"
+#endif
 
 /**
  * \brief Interception table lookup entry.
@@ -19,8 +22,6 @@ struct DeviceInterceptTableEntry
      */
     PFN_vkVoidFunction function;
 };
-
-#define ENTRY(fnc) { STR(fnc), reinterpret_cast<PFN_vkVoidFunction>(layer_##fnc) }
 
 /**
  * \brief The device dispatch table used to call the driver.

--- a/templates/vulkan/codegen_forward/instance_dispatch_table.txt
+++ b/templates/vulkan/codegen_forward/instance_dispatch_table.txt
@@ -3,6 +3,9 @@
 #include <vulkan/vulkan.h>
 
 #include "instance_functions.hpp"
+#if __has_include ("layer_instance_functions.hpp")
+    #include "layer_instance_functions.hpp"
+#endif
 
 /**
  * \brief Interception table lookup entry.
@@ -19,8 +22,6 @@ struct InstanceInterceptTableEntry
      */
     PFN_vkVoidFunction function;
 };
-
-#define ENTRY(fnc) { STR(fnc), reinterpret_cast<PFN_vkVoidFunction>(layer_##fnc) }
 
 /**
  * \brief The instance dispatch table used to call the driver.

--- a/templates/vulkan/codegen_forward/instance_dispatch_table.txt
+++ b/templates/vulkan/codegen_forward/instance_dispatch_table.txt
@@ -29,7 +29,8 @@ struct InstanceInterceptTableEntry
  * \brief The instance dispatch table used to call the driver.
  */
 static const struct InstanceInterceptTableEntry instanceIntercepts[] = {
-{ITABLE_MEMBERS}};
+{ITABLE_MEMBERS}
+};
 
 #undef ENTRY
 
@@ -39,7 +40,8 @@ static const struct InstanceInterceptTableEntry instanceIntercepts[] = {
 struct InstanceDispatchTable {
     PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr;
 
-{DTABLE_MEMBERS}};
+{DTABLE_MEMBERS}
+};
 
 #define ENTRY(fnc) table.fnc = (PFN_##fnc)getProcAddr(instance, STR(fnc))
 
@@ -57,6 +59,7 @@ static inline void initDriverInstanceDispatchTable(
 ) {
     table.vkGetInstanceProcAddr = getProcAddr;
 
-{DTABLE_INITS}}
+{DTABLE_INITS}
+}
 
 #undef ENTRY

--- a/templates/vulkan/codegen_forward/instance_dispatch_table.txt
+++ b/templates/vulkan/codegen_forward/instance_dispatch_table.txt
@@ -23,6 +23,8 @@ struct InstanceInterceptTableEntry
     PFN_vkVoidFunction function;
 };
 
+#define ENTRY(fnc) { STR(fnc), reinterpret_cast<PFN_vkVoidFunction>(layer_##fnc<user_tag>) }
+
 /**
  * \brief The instance dispatch table used to call the driver.
  */

--- a/templates/vulkan/source_forward/source/utils.hpp
+++ b/templates/vulkan/source_forward/source/utils.hpp
@@ -28,6 +28,8 @@
  * This module implements miscellaneous utility functions.
  */
 
+#pragma once
+
 #include <cassert>
 #include <memory>
 #include <string>
@@ -38,6 +40,11 @@
 #ifdef __ANDROID__
   #include <android/log.h>
 #endif
+
+/**
+ * Tag type used for function dispatch;
+ */
+struct user_tag {};
 
 /**
  * \brief Convert a dispatchable API handle to the underlying dispatch key.


### PR DESCRIPTION
Move to using  template-based tag dispatch for layer functions, allowing us to use dynamic function replacement without needing to preprocessor every function. 