### PR TITLE
Common code cleanup

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -82,6 +82,10 @@ jobs:
       - name: Generate layer_test
         run: |
           python3 ./generator/generate_vulkan_common.py
+          mkdir layer_example/build_rel
+          cd layer_example/build_rel
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..
+          make -j4
 
   build-ubuntu-x64-clang-new-project:
     name: Ubuntu x64 generate new layer
@@ -94,6 +98,7 @@ jobs:
 
       - name: Generate layer_test
         run: |
+          python3 ./generator/generate_vulkan_common.py
           python3 ./generator/generate_vulkan_layer.py --project-name Test --layer-name VkLayerTest --output layer_test
           mkdir layer_test/build_rel
           cd layer_test/build_rel

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,9 @@ set(CMAKE_CXX_STANDARD 20)
 
 project(libGPULayers_UnitTests VERSION 1.0.0)
 
+# Standard CMake components
+include(source_common/compiler_helper.cmake)
+
 # Build steps
 set(LGL_UNITTEST ON)
 

--- a/generator/generate_vulkan_layer.py
+++ b/generator/generate_vulkan_layer.py
@@ -429,17 +429,13 @@ def main():
         print(f'ERROR: Layer name "{args.layer_name}" is invalid')
         return 1
 
-    # If overwrite is set, remove output directory if it exists
-    if args.overwrite:
-        shutil.rmtree(args.output, ignore_errors=True)
-
-    # Check that output directory is either empty or non-existent
+    # Check that output directory is either empty or over-writable
     outdir = args.output
     if os.path.exists(outdir):
         if not os.path.isdir(outdir):
             print(f'ERROR: Output location "{outdir}" is not a directory')
             return 1
-        if len(os.listdir(outdir)) != 0:
+        if len(os.listdir(outdir)) != 0 and not args.overwrite:
             print(f'ERROR: Output directory "{outdir}" is not empty')
             return 1
 

--- a/generator/vk_codegen/device_dispatch_table.txt
+++ b/generator/vk_codegen/device_dispatch_table.txt
@@ -2,23 +2,25 @@
 
 #include <vulkan/vulkan.h>
 
-#include "device_functions.hpp"
+#include "framework/device_functions.hpp"
+#include "utils/misc.hpp"
+
 #if __has_include ("layer_device_functions.hpp")
     #include "layer_device_functions.hpp"
 #endif
 
 /**
- * \brief Interception table lookup entry.
+ * @brief Interception table lookup entry.
  */
 struct DeviceInterceptTableEntry
 {
     /**
-     * \brief The function entrypoint name.
+     * @brief The function entrypoint name.
      */
     const char* name;
 
     /**
-     * \brief The layer function pointer.
+     * @brief The layer function pointer.
      */
     PFN_vkVoidFunction function;
 };
@@ -26,7 +28,7 @@ struct DeviceInterceptTableEntry
 #define ENTRY(fnc) { STR(fnc), reinterpret_cast<PFN_vkVoidFunction>(layer_##fnc<user_tag>) }
 
 /**
- * \brief The device dispatch table used to call the driver.
+ * @brief The device dispatch table used to call the driver.
  */
 static const struct DeviceInterceptTableEntry deviceIntercepts[] = {
 {ITABLE_MEMBERS}
@@ -44,11 +46,11 @@ struct DeviceDispatchTable {
 #define ENTRY(fnc) table.fnc = (PFN_##fnc)getProcAddr(device, STR(fnc))
 
 /**
- * \brief Initialize the device dispatch table with driver function pointers.
+ * @brief Initialize the device dispatch table with driver function pointers.
  *
- * \param device        The device handle.
- * \param getProcAddr   The function getter for the driver/next layer down.
- * \param table         The table to populate.
+ * @param device        The device handle.
+ * @param getProcAddr   The function getter for the driver/next layer down.
+ * @param table         The table to populate.
  */
 static inline void initDriverDeviceDispatchTable(
     VkDevice device,

--- a/generator/vk_codegen/instance_dispatch_table.txt
+++ b/generator/vk_codegen/instance_dispatch_table.txt
@@ -2,23 +2,25 @@
 
 #include <vulkan/vulkan.h>
 
-#include "instance_functions.hpp"
+#include "framework/instance_functions.hpp"
+#include "utils/misc.hpp"
+
 #if __has_include ("layer_instance_functions.hpp")
     #include "layer_instance_functions.hpp"
 #endif
 
 /**
- * \brief Interception table lookup entry.
+ * @brief Interception table lookup entry.
  */
 struct InstanceInterceptTableEntry
 {
     /**
-     * \brief The function entrypoint name.
+     * @brief The function entrypoint name.
      */
     const char* name;
 
     /**
-     * \brief The layer function pointer.
+     * @brief The layer function pointer.
      */
     PFN_vkVoidFunction function;
 };
@@ -26,7 +28,7 @@ struct InstanceInterceptTableEntry
 #define ENTRY(fnc) { STR(fnc), reinterpret_cast<PFN_vkVoidFunction>(layer_##fnc<user_tag>) }
 
 /**
- * \brief The instance dispatch table used to call the driver.
+ * @brief The instance dispatch table used to call the driver.
  */
 static const struct InstanceInterceptTableEntry instanceIntercepts[] = {
 {ITABLE_MEMBERS}
@@ -35,7 +37,7 @@ static const struct InstanceInterceptTableEntry instanceIntercepts[] = {
 #undef ENTRY
 
 /**
- * \brief The instance dispatch table used to call the driver.
+ * @brief The instance dispatch table used to call the driver.
  */
 struct InstanceDispatchTable {
     PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr;
@@ -46,11 +48,11 @@ struct InstanceDispatchTable {
 #define ENTRY(fnc) table.fnc = (PFN_##fnc)getProcAddr(instance, STR(fnc))
 
 /**
- * \brief Initialize the instance dispatch table with driver function pointers.
+ * @brief Initialize the instance dispatch table with driver function pointers.
  *
- * \param instance      The instance handle.
- * \param getProcAddr   The function getter for the driver/next layer down.
- * \param table         The table to populate.
+ * @param instance      The instance handle.
+ * @param getProcAddr   The function getter for the driver/next layer down.
+ * @param table         The table to populate.
  */
 static inline void initDriverInstanceDispatchTable(
     VkInstance instance,

--- a/generator/vk_codegen/root_CMakeLists.txt
+++ b/generator/vk_codegen/root_CMakeLists.txt
@@ -29,6 +29,7 @@ project({PROJECT_NAME} VERSION 1.0.0)
 
 # Common configuration
 set(LGL_LOG_TAG, "{LAYER_NAME}")
+include(../source_common/compiler_helper.cmake)
 
 # Build steps
 add_subdirectory(source)

--- a/generator/vk_codegen/source_CMakeLists.txt
+++ b/generator/vk_codegen/source_CMakeLists.txt
@@ -21,18 +21,6 @@
 # SOFTWARE.
 # -----------------------------------------------------------------------------
 
-# Compiler accepts GNU-style command line options
-set(is_gnu_fe1 "$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},GNU>")
-
-# Compiler accepts AppleClang-style command line options, which is also GNU-style
-set(is_gnu_fe2 "$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},AppleClang>")
-
-# Compiler accepts GNU-style command line options
-set(is_gnu_fe "$<OR:${is_gnu_fe1},${is_gnu_fe2}>")
-
-# Compiler is upstream clang with the standard frontend
-set(is_clang "$<AND:${is_gnu_fe},$<CXX_COMPILER_ID:Clang,AppleClang>>")
-
 # Set output file names
 if (CMAKE_BUILD_TYPE STREQUAL "Release")
     set(VK_LAYER {LAYER_NAME}_sym)
@@ -59,7 +47,7 @@ add_library(
 
 target_include_directories(
     ${VK_LAYER} PRIVATE
-        ${PROJECT_SOURCE_DIR}/../source_common/framework
+        ${PROJECT_SOURCE_DIR}/../source_common
         ${CMAKE_CURRENT_BINARY_DIR}
         .)
 
@@ -67,16 +55,7 @@ target_include_directories(
     ${VK_LAYER} SYSTEM PRIVATE
         ../../khronos/vulkan/include)
 
-target_compile_options(
-    ${VK_LAYER} PRIVATE
-        -fvisibility=hidden
-        -fvisibility-inlines-hidden
-        -fno-exceptions
-        -fno-rtti
-        -Wall
-        -Wextra
-        -Wno-missing-field-initializers
-        $<${is_clang}:-Wdocumentation>)
+lgl_set_build_options(${VK_LAYER})
 
 target_compile_definitions(
     ${VK_LAYER} PRIVATE
@@ -85,7 +64,7 @@ target_compile_definitions(
 
 target_link_libraries(
     ${VK_LAYER}
-        layer_common
+        lib_layer_framework
         $<$<PLATFORM_ID:Android>:log>)
 
 if (CMAKE_BUILD_TYPE STREQUAL "Release")

--- a/generator/vk_common/CMakeLists.txt
+++ b/generator/vk_common/CMakeLists.txt
@@ -21,54 +21,32 @@
 # SOFTWARE.
 # -----------------------------------------------------------------------------
 
-# Compiler accepts GNU-style command line options
-set(is_gnu_fe1 "$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},GNU>")
-
-# Compiler accepts AppleClang-style command line options, which is also GNU-style
-set(is_gnu_fe2 "$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},AppleClang>")
-
-# Compiler accepts GNU-style command line options
-set(is_gnu_fe "$<OR:${is_gnu_fe1},${is_gnu_fe2}>")
-
-# Compiler is upstream clang with the standard frontend
-set(is_clang "$<AND:${is_gnu_fe},$<CXX_COMPILER_ID:Clang,AppleClang>>")
-
-set(DIR_TARGET layer_common)
+set(BUILD_TARGET lib_layer_framework)
 
 add_library(
-    ${DIR_TARGET} STATIC
+    ${BUILD_TARGET} STATIC
         device_functions.cpp
         instance_functions.cpp)
 
 target_include_directories(
-    ${DIR_TARGET} PRIVATE
+    ${BUILD_TARGET} PRIVATE
         # Note, this includes from the layer-specific tree
         ${PROJECT_SOURCE_DIR}/source
-        .)
+        ../)
 
 target_include_directories(
-    ${DIR_TARGET} SYSTEM PRIVATE
+    ${BUILD_TARGET} SYSTEM PRIVATE
         ../../khronos/vulkan/include)
 
-target_compile_options(
-    ${DIR_TARGET} PRIVATE
-        -fvisibility=hidden
-        -fvisibility-inlines-hidden
-        -fno-exceptions
-        -fno-rtti
-        -fpic
-        -Wall
-        -Wextra
-        -Wno-missing-field-initializers
-        $<${is_clang}:-Wdocumentation>)
+lgl_set_build_options(${BUILD_TARGET})
 
 # TODO: Log tag needs to come from child project
 target_compile_definitions(
-    ${DIR_TARGET} PRIVATE
+    ${BUILD_TARGET} PRIVATE
         $<$<PLATFORM_ID:Android>:VK_USE_PLATFORM_ANDROID_KHR=1>
         $<$<PLATFORM_ID:Android>:LGL_LOG_TAG="${LGL_LOG_TAG}">)
 
 # TODO: Remove this?
 target_link_libraries(
-    ${DIR_TARGET}
+    ${BUILD_TARGET}
         $<$<PLATFORM_ID:Android>:log>)

--- a/generator/vk_common/entry_utils.hpp
+++ b/generator/vk_common/entry_utils.hpp
@@ -53,7 +53,7 @@
 #endif
 
 /**
- * \brief The layer configuration.
+ * @brief The layer configuration.
  */
 #define LGL_VERSION VK_MAKE_VERSION(LGL_VER_MAJOR, LGL_VER_MINOR, LGL_VER_PATCH)
 
@@ -62,37 +62,37 @@ static const std::array<VkLayerProperties, 1> layerProps = {
 };
 
 /**
- * \brief Dispatch table lookup entry.
+ * @brief Dispatch table lookup entry.
  */
 struct DispatchTableEntry
 {
     /**
-     * \brief The function entrypoint name.
+     * @brief The function entrypoint name.
      */
     const char* name;
 
     /**
-     * \brief The function pointer.
+     * @brief The function pointer.
      */
     PFN_vkVoidFunction function;
 };
 
 /**
- * \brief Utility macro to define a lookup for a core function.
+ * @brief Utility macro to define a lookup for a core function.
  */
 #define VK_TABLE_ENTRY(func) \
     { STR(func), reinterpret_cast<PFN_vkVoidFunction>(func) }
 
 /**
- * \brief Utility macro to define a lookup for a layer-dispatch-only function.
+ * @brief Utility macro to define a lookup for a layer-dispatch-only function.
  */
 #define VK_TABLE_ENTRYL(func) \
     { STR(func), reinterpret_cast<PFN_vkVoidFunction>(layer_##func) }
 
 /**
- * \brief Fetch the layer function for a given instance entrypoint name.
+ * @brief Fetch the layer function for a given instance entrypoint name.
  *
- * \param name   The layer entry point name.
+ * @param name   The layer entry point name.
  *
  * \return The layer function pointer, or \c nullptr if the layer doesn't
  *         intercept the function.
@@ -126,9 +126,9 @@ static PFN_vkVoidFunction get_instance_layer_function(
 }
 
 /**
- * \brief Fetch the layer function for a given device entrypoint name.
+ * @brief Fetch the layer function for a given device entrypoint name.
  *
- * \param name   The layer entry point name.
+ * @param name   The layer entry point name.
  *
  * \return The layer function pointer, or \c nullptr if the layer doesn't intercept the function.
  */

--- a/generator/vk_common/entry_utils.hpp
+++ b/generator/vk_common/entry_utils.hpp
@@ -43,6 +43,7 @@
 #include "device_dispatch_table.hpp"
 #include "device_functions.hpp"
 
+extern std::mutex g_vulkanLock;
 
 #define VK_LAYER_EXPORT __attribute__((visibility("default")))
 

--- a/generator/vk_common/utils.hpp
+++ b/generator/vk_common/utils.hpp
@@ -47,9 +47,9 @@
 struct user_tag {};
 
 /**
- * \brief Convert a dispatchable API handle to the underlying dispatch key.
+ * @brief Convert a dispatchable API handle to the underlying dispatch key.
  *
- * \param ptr   The dispatchable handle from the API.
+ * @param ptr   The dispatchable handle from the API.
  *
  * \return The dispatch key.
  */
@@ -60,22 +60,12 @@ static inline void* getDispatchKey(
 }
 
 /**
- * \brief Macro to stringize a value.
- */
-#define STR(x) #x
-
-/**
- * \brief Macro to mark a variable as unused.
- */
-#define UNUSED(x) ((void)x);
-
-/**
- * \brief Enable to enable API entrypoint tracing to the log/logcat.
+ * @brief Enable to enable API entrypoint tracing to the log/logcat.
  */
 #define CONFIG_TRACE 0
 
 /**
- * \brief Enable to enable layer logging to the log/logcat.
+ * @brief Enable to enable layer logging to the log/logcat.
  */
 #define CONFIG_LOG 1
 
@@ -109,88 +99,3 @@ static inline void* getDispatchKey(
     #define LAYER_LOG(...)
     #define LAYER_ERR(...)
 #endif
-
-/**
- * \brief Format a string using printf formatting template strings.
- *
- * \param format   The template string.
- * \param args     The variadic values used to populate the template.
- */
-template<typename ... Args>
-std::string fmt_string(
-    const std::string& format,
-    Args ... args
-) {
-    // Determine size, adding one for the trailing nul
-    int size = std::snprintf(nullptr, 0, format.c_str(), args ...) + 1;
-    if (size <= 0)
-    {
-        assert(false);
-        return "";
-    }
-
-    // Create the return string
-    std::unique_ptr<char[]> buf(new char[size]);
-    std::snprintf(buf.get(), size, format.c_str(), args ...);
-    return std::string(buf.get(), buf.get() + size - 1);
-}
-
-/**
- * \brief Test if an element exists in an iterable container.
- *
- * \param elem   The element to search for.
- * \param cont   The container to search.
- *
- * \return \c true if the item was found, else \c false.
- */
-template<typename E, typename C>
-bool isIn(const E& elem, const C& cont)
-{
-    return std::find(std::begin(cont), std::end(cont), elem) != std::end(cont);
-}
-
-/**
- * \brief Test if an element exists in a mappable container.
- *
- * \param elem   The element to search for.
- * \param cont   The container to search.
- *
- * \return \c true if the item was found, else \c false.
- */
-template<typename E, typename C>
-bool isInMap(const E& elem, const C& cont)
-{
-    return cont.find(elem) != cont.end();
-}
-
-/**
- * \brief Get the current time in seconds since an arbitrary epoch.
- *
- * \return The current time.
- */
-static inline double getTime()
-{
-    timeval tv;
-    gettimeofday(&tv, 0);
-    return static_cast<double>(tv.tv_sec) + static_cast<double>(tv.tv_usec) * 1.0e-6;
-}
-
-/**
- * \brief Get a displayable pointer.
- *
- * On 64-bit systems this strips the MTE tag.
- *
- * \return The displayable pointer
- */
-static inline uintptr_t getDisplayPointer(
-    void* pointer
-) {
-    uintptr_t dispPointer = reinterpret_cast<uintptr_t>(pointer);
-
-    if constexpr(sizeof(uintptr_t) == 8)
-    {
-        dispPointer &= 0x00FFFFFFFFFFFFFFull;
-    }
-
-    return dispPointer;
-}

--- a/generator/vk_layer/source/device.cpp
+++ b/generator/vk_layer/source/device.cpp
@@ -29,7 +29,8 @@
 #include <sys/stat.h>
 #include <vector>
 
-#include "utils.hpp"
+#include "framework/utils.hpp"
+
 #include "device.hpp"
 #include "instance.hpp"
 

--- a/generator/vk_layer/source/device.cpp
+++ b/generator/vk_layer/source/device.cpp
@@ -81,13 +81,13 @@ void Device::destroy(
 
 /* See header for documentation. */
 Device::Device(
-    Instance* instance,
-    VkPhysicalDevice physicalDevice,
-    VkDevice device,
+    Instance* _instance,
+    VkPhysicalDevice _physicalDevice,
+    VkDevice _device,
     PFN_vkGetDeviceProcAddr nlayerGetProcAddress
-):  instance(instance),
-    physicalDevice(physicalDevice),
-    device(device)
+):  instance(_instance),
+    physicalDevice(_physicalDevice),
+    device(_device)
 {
     initDriverDeviceDispatchTable(device, nlayerGetProcAddress, driver);
 }

--- a/generator/vk_layer/source/device.hpp
+++ b/generator/vk_layer/source/device.hpp
@@ -25,7 +25,7 @@
 
 /**
  * @file
- * Declares the root class for layer management of managing VkDevice objects.
+ * Declares the root class for layer management of VkDevice objects.
  *
  * Role summary
  * ============
@@ -70,7 +70,7 @@ public:
      * @brief Store a new device into the global store of dispatchable devices.
      *
      * @param handle   The dispatchable device handle to use as an indirect key.
-     * @param device   The \c Device object to store.
+     * @param device   The @c Device object to store.
      */
     static void store(
         VkDevice handle,

--- a/generator/vk_layer/source/device.hpp
+++ b/generator/vk_layer/source/device.hpp
@@ -25,88 +25,96 @@
 
 /**
  * @file
- * This module implements layer tracking for VkDevice objects.
+ * Declares the root class for layer management of managing VkDevice objects.
  *
  * Role summary
  * ============
  *
- * Devices represent the core context used by the application to connect to the underlying graphics
- * driver. A device object is the dispatch root for the Vulkan driver, so device commands all take
- * some form of dispatchable handle that can be resolved into a unique per-device key. For the
- * driver this key would simply be a pointer directly to the driver-internal device object, but for
- * our layer we use a device dispatch key as an index in to the map to find the layer's driver
- * object.
+ * Devices represent the core context used by the application to connect to the
+ * underlying graphics driver. A device object is the dispatch root for the
+ * Vulkan driver, so device commands all take some form of dispatchable handle
+ * that can be resolved into a unique per-device key. For the driver this key
+ * would simply be a pointer directly to the driver-internal device object, but
+ * for our layer we use a device dispatch key as an index in to the map to find
+ * the layer's driver object.
  *
  * Key properties
  * ==============
  *
- * Unlike EGL contexts, Vulkan devices are designed to be used concurrently by multiple application
- * threads. An application can have multiple concurrent devices (although this is less common than
- * with OpenGL ES applications), and use each device from multiple threads.
+ * Unlike EGL contexts, Vulkan devices are designed to be used concurrently by
+ * multiple application threads. An application can have multiple concurrent
+ * devices (although this is less common than with OpenGL ES applications), and
+ * use each device from multiple threads.
+ *
+ * Access to the layer driver structures must therefore be kept thread-safe.
+ * For sake of simplicity, we generally implement this by:
+ *   - Holding a global lock whenever any thread is inside layer code.
+ *   - Releasing the global lock whenever the layer calls a driver function.
  */
 
 #pragma once
 
 #include <vulkan/vk_layer.h>
 
+#include "framework/device_dispatch_table.hpp"
+
 #include "instance.hpp"
-#include "device_dispatch_table.hpp"
 
 /**
- * \brief This class implements the layer state tracker for a single device.
+ * @brief This class implements the layer state tracker for a single device.
  */
 class Device
 {
 public:
     /**
-     * \brief Store a new device into the global store of dispatchable devices.
+     * @brief Store a new device into the global store of dispatchable devices.
      *
-     * \param handle   The dispatchable device handle to use as an indirect key.
-     * \param device   The \c Device object to store.
+     * @param handle   The dispatchable device handle to use as an indirect key.
+     * @param device   The \c Device object to store.
      */
     static void store(
         VkDevice handle,
         std::unique_ptr<Device> device);
 
     /**
-     * \brief Fetch a device from the global store of dispatchable devices.
+     * @brief Fetch a device from the global store of dispatchable devices.
      *
-     * \param handle   The dispatchable device handle to use as an indirect lookup.
+     * @param handle   The dispatchable device handle to use as an indirect lookup.
      */
     static Device* retrieve(
         VkDevice handle);
 
     /**
-     * \brief Fetch a device from the global store of dispatchable devices.
+     * @brief Fetch a device from the global store of dispatchable devices.
      *
-     * \param handle   The dispatchable queue handle to use as an indirect lookup.
+     * @param handle   The dispatchable queue handle to use as an indirect lookup.
      */
     static Device* retrieve(
         VkQueue handle);
 
     /**
-     * \brief Fetch a device from the global store of dispatchable devices.
+     * @brief Fetch a device from the global store of dispatchable devices.
      *
-     * \param handle   The dispatchable command buffer handle to use as an indirect lookup.
+     * @param handle   The dispatchable command buffer handle to use as an indirect lookup.
      */
     static Device* retrieve(
         VkCommandBuffer handle);
 
     /**
-     * \brief Drop a device from the global store of dispatchable devices.
+     * @brief Drop a device from the global store of dispatchable devices.
      *
-     * \param device   The device to drop.
+     * @param device   The device to drop.
      */
     static void destroy(
         Device* device);
 
     /**
-     * \brief Create a new layer device object.
+     * @brief Create a new layer device object.
      *
-     * \param instance               The layer instance object this device is created with.
-     * \param physicalDevice         The physical device this logical device is for.
-     * \param device                 The device handle this device is created with.
-     * \param nlayerGetProcAddress   The vkGetProcAddress function in the driver/next layer down.
+     * @param instance               The layer instance object this device is created with.
+     * @param physicalDevice         The physical device this logical device is for.
+     * @param device                 The device handle this device is created with.
+     * @param nlayerGetProcAddress   The vkGetProcAddress function in the driver/next layer down.
      */
     Device(
         Instance* instance,
@@ -115,28 +123,28 @@ public:
         PFN_vkGetDeviceProcAddr nlayerGetProcAddress);
 
     /**
-     * \brief Destroy this layer device object.
+     * @brief Destroy this layer device object.
      */
     ~Device();
 
 public:
     /**
-     * \brief The instance this device is created with.
+     * @brief The instance this device is created with.
      */
     const Instance* instance;
 
     /**
-     * \brief The physical device this device is created with.
+     * @brief The physical device this device is created with.
      */
     const VkPhysicalDevice physicalDevice;
 
     /**
-     * \brief The device handle this device is created with.
+     * @brief The device handle this device is created with.
      */
     const VkDevice device;
 
     /**
-     * \brief The driver function dispatch table.
+     * @brief The driver function dispatch table.
      */
-    DeviceDispatchTable driver { 0 };
+    DeviceDispatchTable driver {};
 };

--- a/generator/vk_layer/source/entry.cpp
+++ b/generator/vk_layer/source/entry.cpp
@@ -35,8 +35,8 @@
 #include <mutex>
 #include <thread>
 
-#include "utils.hpp"
-#include "entry_utils.hpp"
+#include "framework/utils.hpp"
+#include "framework/entry_utils.hpp"
 
 std::mutex g_vulkanLock;
 

--- a/generator/vk_layer/source/instance.cpp
+++ b/generator/vk_layer/source/instance.cpp
@@ -67,10 +67,10 @@ void Instance::destroy(
 
 /* See header for documentation. */
 Instance::Instance(
-    VkInstance instance,
-    PFN_vkGetInstanceProcAddr nlayerGetProcAddress) :
-    instance(instance),
-    nlayerGetProcAddress(nlayerGetProcAddress)
+    VkInstance _instance,
+    PFN_vkGetInstanceProcAddr _nlayerGetProcAddress) :
+    instance(_instance),
+    nlayerGetProcAddress(_nlayerGetProcAddress)
 {
     initDriverInstanceDispatchTable(instance, nlayerGetProcAddress, driver);
 }

--- a/generator/vk_layer/source/instance.cpp
+++ b/generator/vk_layer/source/instance.cpp
@@ -25,7 +25,8 @@
 
 #include <cassert>
 
-#include "utils.hpp"
+#include "framework/utils.hpp"
+
 #include "instance.hpp"
 
 static std::unordered_map<void*, std::unique_ptr<Instance>> g_instances;

--- a/generator/vk_layer/source/instance.hpp
+++ b/generator/vk_layer/source/instance.hpp
@@ -25,7 +25,7 @@
 
 /**
  * @file
- * Declares the root class for layer management of managing VkInstance objects.
+ * Declares the root class for layer management of VkInstance objects.
  *
  * Role summary
  * ============
@@ -77,7 +77,7 @@ public:
      * @brief Store a new instance into the global store of dispatchable instances.
      *
      * @param handle     The dispatchable instance handle to use as an indirect key.
-     * @param instance   The \c Instance object to store.
+     * @param instance   The @c Instance object to store.
      */
     static void store(
         VkInstance handle,

--- a/layer_example/CMakeLists.txt
+++ b/layer_example/CMakeLists.txt
@@ -25,10 +25,11 @@ cmake_minimum_required(VERSION 3.17)
 
 set(CMAKE_CXX_STANDARD 20)
 
-project(Example VERSION 1.0.0)
+project(VkLayerExample VERSION 1.0.0)
 
 # Common configuration
 set(LGL_LOG_TAG, "VkLayerExample")
+include(../source_common/compiler_helper.cmake)
 
 # Build steps
 add_subdirectory(source)

--- a/layer_example/source/CMakeLists.txt
+++ b/layer_example/source/CMakeLists.txt
@@ -21,18 +21,6 @@
 # SOFTWARE.
 # -----------------------------------------------------------------------------
 
-# Compiler accepts GNU-style command line options
-set(is_gnu_fe1 "$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},GNU>")
-
-# Compiler accepts AppleClang-style command line options, which is also GNU-style
-set(is_gnu_fe2 "$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},AppleClang>")
-
-# Compiler accepts GNU-style command line options
-set(is_gnu_fe "$<OR:${is_gnu_fe1},${is_gnu_fe2}>")
-
-# Compiler is upstream clang with the standard frontend
-set(is_clang "$<AND:${is_gnu_fe},$<CXX_COMPILER_ID:Clang,AppleClang>>")
-
 # Set output file names
 if (CMAKE_BUILD_TYPE STREQUAL "Release")
     set(VK_LAYER VkLayerExample_sym)
@@ -60,7 +48,7 @@ add_library(
 
 target_include_directories(
     ${VK_LAYER} PRIVATE
-        ${PROJECT_SOURCE_DIR}/../source_common/framework
+        ${PROJECT_SOURCE_DIR}/../source_common
         ${CMAKE_CURRENT_BINARY_DIR}
         .)
 
@@ -68,16 +56,7 @@ target_include_directories(
     ${VK_LAYER} SYSTEM PRIVATE
         ../../khronos/vulkan/include)
 
-target_compile_options(
-    ${VK_LAYER} PRIVATE
-        -fvisibility=hidden
-        -fvisibility-inlines-hidden
-        -fno-exceptions
-        -fno-rtti
-        -Wall
-        -Wextra
-        -Wno-missing-field-initializers
-        $<${is_clang}:-Wdocumentation>)
+lgl_set_build_options(${VK_LAYER})
 
 target_compile_definitions(
     ${VK_LAYER} PRIVATE
@@ -86,7 +65,7 @@ target_compile_definitions(
 
 target_link_libraries(
     ${VK_LAYER}
-        layer_common
+        lib_layer_framework
         $<$<PLATFORM_ID:Android>:log>)
 
 if (CMAKE_BUILD_TYPE STREQUAL "Release")

--- a/layer_example/source/device.cpp
+++ b/layer_example/source/device.cpp
@@ -29,7 +29,8 @@
 #include <sys/stat.h>
 #include <vector>
 
-#include "utils.hpp"
+#include "framework/utils.hpp"
+
 #include "device.hpp"
 #include "instance.hpp"
 

--- a/layer_example/source/device.cpp
+++ b/layer_example/source/device.cpp
@@ -81,13 +81,13 @@ void Device::destroy(
 
 /* See header for documentation. */
 Device::Device(
-    Instance* instance,
-    VkPhysicalDevice physicalDevice,
-    VkDevice device,
+    Instance* _instance,
+    VkPhysicalDevice _physicalDevice,
+    VkDevice _device,
     PFN_vkGetDeviceProcAddr nlayerGetProcAddress
-):  instance(instance),
-    physicalDevice(physicalDevice),
-    device(device)
+):  instance(_instance),
+    physicalDevice(_physicalDevice),
+    device(_device)
 {
     initDriverDeviceDispatchTable(device, nlayerGetProcAddress, driver);
 }

--- a/layer_example/source/device.hpp
+++ b/layer_example/source/device.hpp
@@ -25,7 +25,7 @@
 
 /**
  * @file
- * Declares the root class for layer management of managing VkDevice objects.
+ * Declares the root class for layer management of VkDevice objects.
  *
  * Role summary
  * ============
@@ -70,7 +70,7 @@ public:
      * @brief Store a new device into the global store of dispatchable devices.
      *
      * @param handle   The dispatchable device handle to use as an indirect key.
-     * @param device   The \c Device object to store.
+     * @param device   The @c Device object to store.
      */
     static void store(
         VkDevice handle,

--- a/layer_example/source/device.hpp
+++ b/layer_example/source/device.hpp
@@ -25,88 +25,96 @@
 
 /**
  * @file
- * This module implements layer tracking for VkDevice objects.
+ * Declares the root class for layer management of managing VkDevice objects.
  *
  * Role summary
  * ============
  *
- * Devices represent the core context used by the application to connect to the underlying graphics
- * driver. A device object is the dispatch root for the Vulkan driver, so device commands all take
- * some form of dispatchable handle that can be resolved into a unique per-device key. For the
- * driver this key would simply be a pointer directly to the driver-internal device object, but for
- * our layer we use a device dispatch key as an index in to the map to find the layer's driver
- * object.
+ * Devices represent the core context used by the application to connect to the
+ * underlying graphics driver. A device object is the dispatch root for the
+ * Vulkan driver, so device commands all take some form of dispatchable handle
+ * that can be resolved into a unique per-device key. For the driver this key
+ * would simply be a pointer directly to the driver-internal device object, but
+ * for our layer we use a device dispatch key as an index in to the map to find
+ * the layer's driver object.
  *
  * Key properties
  * ==============
  *
- * Unlike EGL contexts, Vulkan devices are designed to be used concurrently by multiple application
- * threads. An application can have multiple concurrent devices (although this is less common than
- * with OpenGL ES applications), and use each device from multiple threads.
+ * Unlike EGL contexts, Vulkan devices are designed to be used concurrently by
+ * multiple application threads. An application can have multiple concurrent
+ * devices (although this is less common than with OpenGL ES applications), and
+ * use each device from multiple threads.
+ *
+ * Access to the layer driver structures must therefore be kept thread-safe.
+ * For sake of simplicity, we generally implement this by:
+ *   - Holding a global lock whenever any thread is inside layer code.
+ *   - Releasing the global lock whenever the layer calls a driver function.
  */
 
 #pragma once
 
 #include <vulkan/vk_layer.h>
 
+#include "framework/device_dispatch_table.hpp"
+
 #include "instance.hpp"
-#include "device_dispatch_table.hpp"
 
 /**
- * \brief This class implements the layer state tracker for a single device.
+ * @brief This class implements the layer state tracker for a single device.
  */
 class Device
 {
 public:
     /**
-     * \brief Store a new device into the global store of dispatchable devices.
+     * @brief Store a new device into the global store of dispatchable devices.
      *
-     * \param handle   The dispatchable device handle to use as an indirect key.
-     * \param device   The \c Device object to store.
+     * @param handle   The dispatchable device handle to use as an indirect key.
+     * @param device   The \c Device object to store.
      */
     static void store(
         VkDevice handle,
         std::unique_ptr<Device> device);
 
     /**
-     * \brief Fetch a device from the global store of dispatchable devices.
+     * @brief Fetch a device from the global store of dispatchable devices.
      *
-     * \param handle   The dispatchable device handle to use as an indirect lookup.
+     * @param handle   The dispatchable device handle to use as an indirect lookup.
      */
     static Device* retrieve(
         VkDevice handle);
 
     /**
-     * \brief Fetch a device from the global store of dispatchable devices.
+     * @brief Fetch a device from the global store of dispatchable devices.
      *
-     * \param handle   The dispatchable queue handle to use as an indirect lookup.
+     * @param handle   The dispatchable queue handle to use as an indirect lookup.
      */
     static Device* retrieve(
         VkQueue handle);
 
     /**
-     * \brief Fetch a device from the global store of dispatchable devices.
+     * @brief Fetch a device from the global store of dispatchable devices.
      *
-     * \param handle   The dispatchable command buffer handle to use as an indirect lookup.
+     * @param handle   The dispatchable command buffer handle to use as an indirect lookup.
      */
     static Device* retrieve(
         VkCommandBuffer handle);
 
     /**
-     * \brief Drop a device from the global store of dispatchable devices.
+     * @brief Drop a device from the global store of dispatchable devices.
      *
-     * \param device   The device to drop.
+     * @param device   The device to drop.
      */
     static void destroy(
         Device* device);
 
     /**
-     * \brief Create a new layer device object.
+     * @brief Create a new layer device object.
      *
-     * \param instance               The layer instance object this device is created with.
-     * \param physicalDevice         The physical device this logical device is for.
-     * \param device                 The device handle this device is created with.
-     * \param nlayerGetProcAddress   The vkGetProcAddress function in the driver/next layer down.
+     * @param instance               The layer instance object this device is created with.
+     * @param physicalDevice         The physical device this logical device is for.
+     * @param device                 The device handle this device is created with.
+     * @param nlayerGetProcAddress   The vkGetProcAddress function in the driver/next layer down.
      */
     Device(
         Instance* instance,
@@ -115,28 +123,28 @@ public:
         PFN_vkGetDeviceProcAddr nlayerGetProcAddress);
 
     /**
-     * \brief Destroy this layer device object.
+     * @brief Destroy this layer device object.
      */
     ~Device();
 
 public:
     /**
-     * \brief The instance this device is created with.
+     * @brief The instance this device is created with.
      */
     const Instance* instance;
 
     /**
-     * \brief The physical device this device is created with.
+     * @brief The physical device this device is created with.
      */
     const VkPhysicalDevice physicalDevice;
 
     /**
-     * \brief The device handle this device is created with.
+     * @brief The device handle this device is created with.
      */
     const VkDevice device;
 
     /**
-     * \brief The driver function dispatch table.
+     * @brief The driver function dispatch table.
      */
-    DeviceDispatchTable driver { 0 };
+    DeviceDispatchTable driver {};
 };

--- a/layer_example/source/entry.cpp
+++ b/layer_example/source/entry.cpp
@@ -35,8 +35,8 @@
 #include <mutex>
 #include <thread>
 
-#include "utils.hpp"
-#include "entry_utils.hpp"
+#include "framework/utils.hpp"
+#include "framework/entry_utils.hpp"
 
 std::mutex g_vulkanLock;
 

--- a/layer_example/source/instance.cpp
+++ b/layer_example/source/instance.cpp
@@ -67,10 +67,10 @@ void Instance::destroy(
 
 /* See header for documentation. */
 Instance::Instance(
-    VkInstance instance,
-    PFN_vkGetInstanceProcAddr nlayerGetProcAddress) :
-    instance(instance),
-    nlayerGetProcAddress(nlayerGetProcAddress)
+    VkInstance _instance,
+    PFN_vkGetInstanceProcAddr _nlayerGetProcAddress) :
+    instance(_instance),
+    nlayerGetProcAddress(_nlayerGetProcAddress)
 {
     initDriverInstanceDispatchTable(instance, nlayerGetProcAddress, driver);
 }

--- a/layer_example/source/instance.cpp
+++ b/layer_example/source/instance.cpp
@@ -25,7 +25,8 @@
 
 #include <cassert>
 
-#include "utils.hpp"
+#include "framework/utils.hpp"
+
 #include "instance.hpp"
 
 static std::unordered_map<void*, std::unique_ptr<Instance>> g_instances;

--- a/layer_example/source/instance.hpp
+++ b/layer_example/source/instance.hpp
@@ -25,7 +25,7 @@
 
 /**
  * @file
- * Declares the root class for layer management of managing VkInstance objects.
+ * Declares the root class for layer management of VkInstance objects.
  *
  * Role summary
  * ============
@@ -77,7 +77,7 @@ public:
      * @brief Store a new instance into the global store of dispatchable instances.
      *
      * @param handle     The dispatchable instance handle to use as an indirect key.
-     * @param instance   The \c Instance object to store.
+     * @param instance   The @c Instance object to store.
      */
     static void store(
         VkInstance handle,

--- a/layer_example/source/layer_device_functions.cpp
+++ b/layer_example/source/layer_device_functions.cpp
@@ -27,7 +27,8 @@
 #include <mutex>
 #include <thread>
 
-#include "utils.hpp"
+#include "framework/utils.hpp"
+
 #include "device.hpp"
 #include "layer_device_functions.hpp"
 

--- a/layer_example/source/layer_device_functions.hpp
+++ b/layer_example/source/layer_device_functions.hpp
@@ -27,9 +27,10 @@
 #include <mutex>
 #include <thread>
 
-#include "utils.hpp"
+#include "framework/device_functions.hpp"
+#include "framework/utils.hpp"
+
 #include "device.hpp"
-#include "device_functions.hpp"
 
 extern std::mutex g_vulkanLock;
 
@@ -40,14 +41,12 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass<user_tag>(
     const VkRenderPassBeginInfo* pRenderPassBegin,
     VkSubpassContents contents);
 
-
 /* See Vulkan API for documentation. */
 template <>
 VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2<user_tag>(
     VkCommandBuffer commandBuffer,
     const VkRenderPassBeginInfo* pRenderPassBegin,
     const VkSubpassBeginInfo* pSubpassBeginInfo);
-
 
 /* See Vulkan API for documentation. */
 template <>
@@ -56,13 +55,11 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2KHR<user_tag>(
     const VkRenderPassBeginInfo* pRenderPassBegin,
     const VkSubpassBeginInfo* pSubpassBeginInfo);
 
-
 /* See Vulkan API for documentation. */
 template <>
 VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRendering<user_tag>(
     VkCommandBuffer commandBuffer,
     const VkRenderingInfo* pRenderingInfo);
-
 
 /* See Vulkan API for documentation. */
 template <>

--- a/source_common/CMakeLists.txt
+++ b/source_common/CMakeLists.txt
@@ -26,4 +26,3 @@
 # Device classes which get specialized for each use case.
 
 add_subdirectory(comms)
-add_subdirectory(trackers)

--- a/source_common/CMakeLists.txt
+++ b/source_common/CMakeLists.txt
@@ -26,3 +26,4 @@
 # Device classes which get specialized for each use case.
 
 add_subdirectory(comms)
+add_subdirectory(trackers)

--- a/source_common/CMakeLists.txt
+++ b/source_common/CMakeLists.txt
@@ -21,4 +21,8 @@
 # SOFTWARE.
 # -----------------------------------------------------------------------------
 
+# Note: The framework component cannot be built as a common library, because it
+# depends on per-layer implementations of the root intercept Instance and
+# Device classes which get specialized for each use case.
+
 add_subdirectory(comms)

--- a/source_common/comms/test/CMakeLists.txt
+++ b/source_common/comms/test/CMakeLists.txt
@@ -64,9 +64,11 @@ target_link_libraries(
         lib_layer_comms
         gtest_main)
 
-add_test(
-    NAME ${TEST_BINARY}
-    COMMAND ${TEST_BINARY})
+# Exclude from ctest for now because it needs user to manually run the
+# external server program before the test can pass
+#add_test(
+#    NAME ${TEST_BINARY}
+#    COMMAND ${TEST_BINARY})
 
 install(
     TARGETS ${TEST_BINARY}

--- a/source_common/compiler_helper.cmake
+++ b/source_common/compiler_helper.cmake
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: MIT
+# -----------------------------------------------------------------------------
+# Copyright (c) 2024 Arm Limited
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+# -----------------------------------------------------------------------------
+
+# Compiler accepts MSVC-style command line options
+set(is_msvc_fe "$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},MSVC>")
+
+# Compiler accepts GNU-style command line options
+set(is_gnu_fe1 "$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},GNU>")
+
+# Compiler accepts AppleClang-style command line options, which is also GNU-style
+set(is_gnu_fe2 "$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},AppleClang>")
+
+# Compiler accepts GNU-style command line options
+set(is_gnu_fe "$<OR:${is_gnu_fe1},${is_gnu_fe2}>")
+
+# Compiler is Visual Studio cl.exe
+set(is_msvccl "$<AND:${is_msvc_fe},$<CXX_COMPILER_ID:MSVC>>")
+
+# Compiler is Visual Studio clangcl.exe
+set(is_clangcl "$<AND:${is_msvc_fe},$<CXX_COMPILER_ID:Clang>>")
+
+# Compiler is upstream clang with the standard frontend
+set(is_clang "$<AND:${is_gnu_fe},$<CXX_COMPILER_ID:Clang,AppleClang>>")
+
+# Utility macro to set standard compiler options
+macro(lgl_set_build_options BUILD_TARGET_NAME)
+
+    target_compile_options(
+        ${BUILD_TARGET_NAME} PRIVATE
+            # Minimized visibility warnings
+            $<${is_gnu_fe}:-fvisibility=hidden>
+            $<${is_gnu_fe}:-fvisibility-inlines-hidden>
+
+            # Strict warnings
+            $<${is_gnu_fe}:-Wall>
+            $<${is_gnu_fe}:-Wextra>
+            $<${is_gnu_fe}:-Wpedantic>
+            $<${is_gnu_fe}:-Werror>
+            $<${is_gnu_fe}:-Wshadow>
+            $<${is_gnu_fe}:-Wdouble-promotion>
+            $<${is_clang}:-Wdocumentation>
+
+            # Feature disabled
+            $<${is_gnu_fe}:-fno-exceptions>
+            $<${is_gnu_fe}:-fno-rtti>)
+
+endmacro()

--- a/source_common/framework/CMakeLists.txt
+++ b/source_common/framework/CMakeLists.txt
@@ -21,54 +21,32 @@
 # SOFTWARE.
 # -----------------------------------------------------------------------------
 
-# Compiler accepts GNU-style command line options
-set(is_gnu_fe1 "$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},GNU>")
-
-# Compiler accepts AppleClang-style command line options, which is also GNU-style
-set(is_gnu_fe2 "$<STREQUAL:${CMAKE_CXX_COMPILER_FRONTEND_VARIANT},AppleClang>")
-
-# Compiler accepts GNU-style command line options
-set(is_gnu_fe "$<OR:${is_gnu_fe1},${is_gnu_fe2}>")
-
-# Compiler is upstream clang with the standard frontend
-set(is_clang "$<AND:${is_gnu_fe},$<CXX_COMPILER_ID:Clang,AppleClang>>")
-
-set(DIR_TARGET layer_common)
+set(BUILD_TARGET lib_layer_framework)
 
 add_library(
-    ${DIR_TARGET} STATIC
+    ${BUILD_TARGET} STATIC
         device_functions.cpp
         instance_functions.cpp)
 
 target_include_directories(
-    ${DIR_TARGET} PRIVATE
+    ${BUILD_TARGET} PRIVATE
         # Note, this includes from the layer-specific tree
         ${PROJECT_SOURCE_DIR}/source
-        .)
+        ../)
 
 target_include_directories(
-    ${DIR_TARGET} SYSTEM PRIVATE
+    ${BUILD_TARGET} SYSTEM PRIVATE
         ../../khronos/vulkan/include)
 
-target_compile_options(
-    ${DIR_TARGET} PRIVATE
-        -fvisibility=hidden
-        -fvisibility-inlines-hidden
-        -fno-exceptions
-        -fno-rtti
-        -fpic
-        -Wall
-        -Wextra
-        -Wno-missing-field-initializers
-        $<${is_clang}:-Wdocumentation>)
+lgl_set_build_options(${BUILD_TARGET})
 
 # TODO: Log tag needs to come from child project
 target_compile_definitions(
-    ${DIR_TARGET} PRIVATE
+    ${BUILD_TARGET} PRIVATE
         $<$<PLATFORM_ID:Android>:VK_USE_PLATFORM_ANDROID_KHR=1>
         $<$<PLATFORM_ID:Android>:LGL_LOG_TAG="${LGL_LOG_TAG}">)
 
 # TODO: Remove this?
 target_link_libraries(
-    ${DIR_TARGET}
+    ${BUILD_TARGET}
         $<$<PLATFORM_ID:Android>:log>)

--- a/source_common/framework/device_dispatch_table.hpp
+++ b/source_common/framework/device_dispatch_table.hpp
@@ -27,23 +27,25 @@
 
 #include <vulkan/vulkan.h>
 
-#include "device_functions.hpp"
+#include "framework/device_functions.hpp"
+#include "utils/misc.hpp"
+
 #if __has_include ("layer_device_functions.hpp")
     #include "layer_device_functions.hpp"
 #endif
 
 /**
- * \brief Interception table lookup entry.
+ * @brief Interception table lookup entry.
  */
 struct DeviceInterceptTableEntry
 {
     /**
-     * \brief The function entrypoint name.
+     * @brief The function entrypoint name.
      */
     const char* name;
 
     /**
-     * \brief The layer function pointer.
+     * @brief The layer function pointer.
      */
     PFN_vkVoidFunction function;
 };
@@ -51,7 +53,7 @@ struct DeviceInterceptTableEntry
 #define ENTRY(fnc) { STR(fnc), reinterpret_cast<PFN_vkVoidFunction>(layer_##fnc<user_tag>) }
 
 /**
- * \brief The device dispatch table used to call the driver.
+ * @brief The device dispatch table used to call the driver.
  */
 static const struct DeviceInterceptTableEntry deviceIntercepts[] = {
     ENTRY(vkAcquireNextImage2KHR),
@@ -961,11 +963,11 @@ struct DeviceDispatchTable {
 #define ENTRY(fnc) table.fnc = (PFN_##fnc)getProcAddr(device, STR(fnc))
 
 /**
- * \brief Initialize the device dispatch table with driver function pointers.
+ * @brief Initialize the device dispatch table with driver function pointers.
  *
- * \param device        The device handle.
- * \param getProcAddr   The function getter for the driver/next layer down.
- * \param table         The table to populate.
+ * @param device        The device handle.
+ * @param getProcAddr   The function getter for the driver/next layer down.
+ * @param table         The table to populate.
  */
 static inline void initDriverDeviceDispatchTable(
     VkDevice device,

--- a/source_common/framework/entry_utils.hpp
+++ b/source_common/framework/entry_utils.hpp
@@ -43,7 +43,6 @@
 #include "device_dispatch_table.hpp"
 #include "device_functions.hpp"
 
-extern std::mutex g_vulkanLock;
 
 #define VK_LAYER_EXPORT __attribute__((visibility("default")))
 
@@ -54,7 +53,7 @@ extern std::mutex g_vulkanLock;
 #endif
 
 /**
- * \brief The layer configuration.
+ * @brief The layer configuration.
  */
 #define LGL_VERSION VK_MAKE_VERSION(LGL_VER_MAJOR, LGL_VER_MINOR, LGL_VER_PATCH)
 
@@ -63,37 +62,37 @@ static const std::array<VkLayerProperties, 1> layerProps = {
 };
 
 /**
- * \brief Dispatch table lookup entry.
+ * @brief Dispatch table lookup entry.
  */
 struct DispatchTableEntry
 {
     /**
-     * \brief The function entrypoint name.
+     * @brief The function entrypoint name.
      */
     const char* name;
 
     /**
-     * \brief The function pointer.
+     * @brief The function pointer.
      */
     PFN_vkVoidFunction function;
 };
 
 /**
- * \brief Utility macro to define a lookup for a core function.
+ * @brief Utility macro to define a lookup for a core function.
  */
 #define VK_TABLE_ENTRY(func) \
     { STR(func), reinterpret_cast<PFN_vkVoidFunction>(func) }
 
 /**
- * \brief Utility macro to define a lookup for a layer-dispatch-only function.
+ * @brief Utility macro to define a lookup for a layer-dispatch-only function.
  */
 #define VK_TABLE_ENTRYL(func) \
     { STR(func), reinterpret_cast<PFN_vkVoidFunction>(layer_##func) }
 
 /**
- * \brief Fetch the layer function for a given instance entrypoint name.
+ * @brief Fetch the layer function for a given instance entrypoint name.
  *
- * \param name   The layer entry point name.
+ * @param name   The layer entry point name.
  *
  * \return The layer function pointer, or \c nullptr if the layer doesn't
  *         intercept the function.
@@ -127,9 +126,9 @@ static PFN_vkVoidFunction get_instance_layer_function(
 }
 
 /**
- * \brief Fetch the layer function for a given device entrypoint name.
+ * @brief Fetch the layer function for a given device entrypoint name.
  *
- * \param name   The layer entry point name.
+ * @param name   The layer entry point name.
  *
  * \return The layer function pointer, or \c nullptr if the layer doesn't intercept the function.
  */

--- a/source_common/framework/entry_utils.hpp
+++ b/source_common/framework/entry_utils.hpp
@@ -43,6 +43,7 @@
 #include "device_dispatch_table.hpp"
 #include "device_functions.hpp"
 
+extern std::mutex g_vulkanLock;
 
 #define VK_LAYER_EXPORT __attribute__((visibility("default")))
 

--- a/source_common/framework/instance_dispatch_table.hpp
+++ b/source_common/framework/instance_dispatch_table.hpp
@@ -27,23 +27,25 @@
 
 #include <vulkan/vulkan.h>
 
-#include "instance_functions.hpp"
+#include "framework/instance_functions.hpp"
+#include "utils/misc.hpp"
+
 #if __has_include ("layer_instance_functions.hpp")
     #include "layer_instance_functions.hpp"
 #endif
 
 /**
- * \brief Interception table lookup entry.
+ * @brief Interception table lookup entry.
  */
 struct InstanceInterceptTableEntry
 {
     /**
-     * \brief The function entrypoint name.
+     * @brief The function entrypoint name.
      */
     const char* name;
 
     /**
-     * \brief The layer function pointer.
+     * @brief The layer function pointer.
      */
     PFN_vkVoidFunction function;
 };
@@ -51,7 +53,7 @@ struct InstanceInterceptTableEntry
 #define ENTRY(fnc) { STR(fnc), reinterpret_cast<PFN_vkVoidFunction>(layer_##fnc<user_tag>) }
 
 /**
- * \brief The instance dispatch table used to call the driver.
+ * @brief The instance dispatch table used to call the driver.
  */
 static const struct InstanceInterceptTableEntry instanceIntercepts[] = {
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
@@ -131,7 +133,7 @@ static const struct InstanceInterceptTableEntry instanceIntercepts[] = {
 #undef ENTRY
 
 /**
- * \brief The instance dispatch table used to call the driver.
+ * @brief The instance dispatch table used to call the driver.
  */
 struct InstanceDispatchTable {
     PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr;
@@ -212,11 +214,11 @@ struct InstanceDispatchTable {
 #define ENTRY(fnc) table.fnc = (PFN_##fnc)getProcAddr(instance, STR(fnc))
 
 /**
- * \brief Initialize the instance dispatch table with driver function pointers.
+ * @brief Initialize the instance dispatch table with driver function pointers.
  *
- * \param instance      The instance handle.
- * \param getProcAddr   The function getter for the driver/next layer down.
- * \param table         The table to populate.
+ * @param instance      The instance handle.
+ * @param getProcAddr   The function getter for the driver/next layer down.
+ * @param table         The table to populate.
  */
 static inline void initDriverInstanceDispatchTable(
     VkInstance instance,

--- a/source_common/framework/utils.hpp
+++ b/source_common/framework/utils.hpp
@@ -47,9 +47,9 @@
 struct user_tag {};
 
 /**
- * \brief Convert a dispatchable API handle to the underlying dispatch key.
+ * @brief Convert a dispatchable API handle to the underlying dispatch key.
  *
- * \param ptr   The dispatchable handle from the API.
+ * @param ptr   The dispatchable handle from the API.
  *
  * \return The dispatch key.
  */
@@ -60,22 +60,12 @@ static inline void* getDispatchKey(
 }
 
 /**
- * \brief Macro to stringize a value.
- */
-#define STR(x) #x
-
-/**
- * \brief Macro to mark a variable as unused.
- */
-#define UNUSED(x) ((void)x);
-
-/**
- * \brief Enable to enable API entrypoint tracing to the log/logcat.
+ * @brief Enable to enable API entrypoint tracing to the log/logcat.
  */
 #define CONFIG_TRACE 0
 
 /**
- * \brief Enable to enable layer logging to the log/logcat.
+ * @brief Enable to enable layer logging to the log/logcat.
  */
 #define CONFIG_LOG 1
 
@@ -109,88 +99,3 @@ static inline void* getDispatchKey(
     #define LAYER_LOG(...)
     #define LAYER_ERR(...)
 #endif
-
-/**
- * \brief Format a string using printf formatting template strings.
- *
- * \param format   The template string.
- * \param args     The variadic values used to populate the template.
- */
-template<typename ... Args>
-std::string fmt_string(
-    const std::string& format,
-    Args ... args
-) {
-    // Determine size, adding one for the trailing nul
-    int size = std::snprintf(nullptr, 0, format.c_str(), args ...) + 1;
-    if (size <= 0)
-    {
-        assert(false);
-        return "";
-    }
-
-    // Create the return string
-    std::unique_ptr<char[]> buf(new char[size]);
-    std::snprintf(buf.get(), size, format.c_str(), args ...);
-    return std::string(buf.get(), buf.get() + size - 1);
-}
-
-/**
- * \brief Test if an element exists in an iterable container.
- *
- * \param elem   The element to search for.
- * \param cont   The container to search.
- *
- * \return \c true if the item was found, else \c false.
- */
-template<typename E, typename C>
-bool isIn(const E& elem, const C& cont)
-{
-    return std::find(std::begin(cont), std::end(cont), elem) != std::end(cont);
-}
-
-/**
- * \brief Test if an element exists in a mappable container.
- *
- * \param elem   The element to search for.
- * \param cont   The container to search.
- *
- * \return \c true if the item was found, else \c false.
- */
-template<typename E, typename C>
-bool isInMap(const E& elem, const C& cont)
-{
-    return cont.find(elem) != cont.end();
-}
-
-/**
- * \brief Get the current time in seconds since an arbitrary epoch.
- *
- * \return The current time.
- */
-static inline double getTime()
-{
-    timeval tv;
-    gettimeofday(&tv, 0);
-    return static_cast<double>(tv.tv_sec) + static_cast<double>(tv.tv_usec) * 1.0e-6;
-}
-
-/**
- * \brief Get a displayable pointer.
- *
- * On 64-bit systems this strips the MTE tag.
- *
- * \return The displayable pointer
- */
-static inline uintptr_t getDisplayPointer(
-    void* pointer
-) {
-    uintptr_t dispPointer = reinterpret_cast<uintptr_t>(pointer);
-
-    if constexpr(sizeof(uintptr_t) == 8)
-    {
-        dispPointer &= 0x00FFFFFFFFFFFFFFull;
-    }
-
-    return dispPointer;
-}

--- a/source_common/utils/misc.hpp
+++ b/source_common/utils/misc.hpp
@@ -1,16 +1,34 @@
 /*
- * This confidential and proprietary software may be used only as
- * authorised by a licensing agreement from Arm Limited.
- *    Copyright 2022-2024 Arm Ltd. All Rights Reserved.
- * The entire notice above must be reproduced on all authorised
- * copies and copies may only be made to the extent permitted
- * by a licensing agreement from Arm Limited.
+ * SPDX-License-Identifier: MIT
+ * ----------------------------------------------------------------------------
+ * Copyright (c) 2022-2024 Arm Limited
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ * ----------------------------------------------------------------------------
  */
 
 /**
  * @file
  * This module implements miscellaneous utility functions.
  */
+
+#pragma once
 
 #include <cassert>
 #include <string>

--- a/source_common/utils/misc.hpp
+++ b/source_common/utils/misc.hpp
@@ -1,0 +1,103 @@
+/*
+ * This confidential and proprietary software may be used only as
+ * authorised by a licensing agreement from Arm Limited.
+ *    Copyright 2022-2024 Arm Ltd. All Rights Reserved.
+ * The entire notice above must be reproduced on all authorised
+ * copies and copies may only be made to the extent permitted
+ * by a licensing agreement from Arm Limited.
+ */
+
+/**
+ * @file
+ * This module implements miscellaneous utility functions.
+ */
+
+#include <cassert>
+#include <string>
+
+/**
+ * @brief Macro to stringize a value.
+ */
+#define STR(x) #x
+
+/**
+ * @brief Macro to mark a variable as unused.
+ */
+#define UNUSED(x) ((void)x);
+
+/**
+ * @brief Format a string using printf formatting template strings.
+ *
+ * @param format   The template string.
+ * @param args     The variadic values used to populate the template.
+ */
+template<typename ... Args>
+std::string fmt_string(
+    const std::string& format,
+    Args ... args
+) {
+    // Determine size, adding one for the trailing nul
+    int size = std::snprintf(nullptr, 0, format.c_str(), args ...) + 1;
+    if (size <= 0)
+    {
+        assert(false);
+        return "";
+    }
+
+    // Create the return string
+    std::unique_ptr<char[]> buf(new char[size]);
+    std::snprintf(buf.get(), size, format.c_str(), args ...);
+    return std::string(buf.get(), buf.get() + size - 1);
+}
+
+/**
+ * @brief Test if an element exists in an iterable container.
+ *
+ * @param elem   The element to search for.
+ * @param cont   The container to search.
+ *
+ * @return @c true if the item was found, else @c false.
+ */
+template<typename E, typename C>
+bool isIn(
+    const E& elem,
+    const C& cont
+) {
+    return std::find(std::begin(cont), std::end(cont), elem) != std::end(cont);
+}
+
+/**
+ * @brief Test if an element exists in a mappable container.
+ *
+ * @param elem   The element to search for.
+ * @param cont   The container to search.
+ *
+ * @return @c true if the item was found, else @c false.
+ */
+template<typename E, typename C>
+bool isInMap(
+    const E& elem,
+    const C& cont
+) {
+    return cont.find(elem) != cont.end();
+}
+
+/**
+ * @brief Get a displayable pointer.
+ *
+ * On 64-bit systems this strips the MTE tag.
+ *
+ * @return The displayable pointer
+ */
+static inline uintptr_t getDisplayPointer(
+    void* pointer
+) {
+    uintptr_t dispPointer = reinterpret_cast<uintptr_t>(pointer);
+
+    if constexpr(sizeof(uintptr_t) == 8)
+    {
+        dispPointer &= 0x00FFFFFFFFFFFFFFull;
+    }
+
+    return dispPointer;
+}


### PR DESCRIPTION
A collection of source code cleanups for the generated code:

* Consistent Doxygen style (must use @ everywhere).
* Consistent include path style (must include prefix directory for common code). 
* Consistent license header (fix one missing use of Arm proprietary preamble I missed).
* Moves CMake compiler helper to common .cmake file.
* Allows layer code to write over existing layer code to facilitate updates.