### PR TITLE
Fix comms module compiler warnings

### DIFF
--- a/source_common/comms/CMakeLists.txt
+++ b/source_common/comms/CMakeLists.txt
@@ -25,6 +25,7 @@ set(LIB_BINARY lib_layer_comms)
 
 add_library(
     ${LIB_BINARY} STATIC
+        comms_message.cpp
         comms_module.cpp
         comms_receiver.cpp
         comms_transmitter.cpp)

--- a/source_common/comms/comms_message.cpp
+++ b/source_common/comms/comms_message.cpp
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * ----------------------------------------------------------------------------
+ * Copyright (c) 2024 Arm Limited
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ * ----------------------------------------------------------------------------
+ */
+
+/**
+ * @file
+ * The declaration of the communication module internal message types.
+ */
+
+#include "comms/comms_message.hpp"
+
+namespace Comms
+{
+
+Message::Message(
+    EndpointID _endpointID,
+    MessageType _messageType,
+    MessageID _messageID,
+    std::unique_ptr<MessageData> _transmitData) :
+    endpointID(_endpointID),
+    messageType(_messageType),
+    messageID(_messageID),
+    transmitData(std::move(_transmitData))
+{
+
+}
+
+}

--- a/source_common/comms/comms_message.hpp
+++ b/source_common/comms/comms_message.hpp
@@ -83,11 +83,7 @@ public:
         EndpointID endpointID,
         MessageType messageType,
         MessageID messageID,
-        std::unique_ptr<MessageData> transmitData) :
-        endpointID(endpointID),
-        messageType(messageType),
-        messageID(messageID),
-        transmitData(std::move(transmitData)) { }
+        std::unique_ptr<MessageData> transmitData);
 
     /**
      * @brief The type of the message.

--- a/source_common/comms/comms_module.cpp
+++ b/source_common/comms/comms_module.cpp
@@ -186,7 +186,7 @@ EndpointID CommsModule::getEndpointID(
         return registry[name];
     }
     // Service not found
-    catch(std::out_of_range)
+    catch(std::out_of_range const&)
     {
         return NO_ENDPOINT;
     }

--- a/source_common/comms/comms_receiver.cpp
+++ b/source_common/comms/comms_receiver.cpp
@@ -42,8 +42,8 @@ namespace Comms
 {
 /** See header for documentation. */
 Receiver::Receiver(
-    CommsModule& parent
-) : parent(parent)
+    CommsModule& _parent
+) : parent(_parent)
 {
     int pipe_err = pipe(stopRequestPipe);
     if (pipe_err)
@@ -77,7 +77,7 @@ void Receiver::stop()
 
     // Poke the pipe to wake the worker thread if it is blocked on a read
     int data = 0xdead;
-    write(stopRequestPipe[1], &data, sizeof(int));
+    [[maybe_unused]] int _ = write(stopRequestPipe[1], &data, sizeof(int));
 
     // Join on the worker thread
     worker.join();

--- a/source_common/comms/comms_transmitter.cpp
+++ b/source_common/comms/comms_transmitter.cpp
@@ -39,8 +39,8 @@ namespace Comms
 
 /** See header for documentation. */
 Transmitter::Transmitter(
-    CommsModule& parent
-) : parent(parent)
+    CommsModule& _parent
+) : parent(_parent)
 {
     // Create and start a worker thread
     worker = std::thread(&Transmitter::runTransmitter, this);


### PR DESCRIPTION
Minor code cleanup in the comms module to fix 
compiler warnings triggered by Clang in the 
latest Android NDK.