### PR TITLE
Timeline JSON preserves stack

### DIFF
--- a/lglpy/timeline/data/raw_trace.py
+++ b/lglpy/timeline/data/raw_trace.py
@@ -200,10 +200,7 @@ class MetadataWorkload:
         self.frame = frame
         self.tag_id = int(metadata['tid'])
 
-        self.label_stack = None
-        label_stack = metadata.get('label', None)
-        if label_stack:
-            self.label_stack = label_stack.split('|')
+        self.label_stack = metadata.get('label', None)
 
     def get_perfetto_tag_id(self) -> str:
         '''
@@ -310,9 +307,6 @@ class MetadataBufferTransfer(MetadataWorkload):
     Parsed GPU Timeline layer payload for a transfer that writes a buffer.
 
     Attributes:
-        frame: The frame index in the application.
-        tag_id: The unique workload tag ID to cross-reference with Perfetto.
-        label_stack: Debug label stack, or None if no user labels.
         subtype: Specific type of the transfer.
         byte_count: Number of bytes written, or -1 if unknown.
     '''
@@ -641,7 +635,6 @@ class RawTrace:
 
         # Extract render stages events from Perfetto data
         for packet in protoc.packet:
-
             # Clock sync packet so update clock drift information
             if packet.HasField('clock_snapshot'):
                 config.add_clock_sync_data(packet)

--- a/source_common/trackers/layer_command_stream.cpp
+++ b/source_common/trackers/layer_command_stream.cpp
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: MIT
  * ----------------------------------------------------------------------------
- * Copyright (c) 2024 Arm Limited
+ * Copyright (c) 2024-2025 Arm Limited
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to
@@ -75,7 +75,7 @@ LCSRenderPass::LCSRenderPass(
 
 /* See header for details. */
 std::string LCSRenderPass::getBeginMetadata(
-    const std::string* debugLabel) const
+     const std::vector<std::string>* debugLabel) const
 {
     // Draw count for a multi-submit command buffer cannot be reliably
     // associated with a single tagID if restartable across command buffer
@@ -140,7 +140,7 @@ std::string LCSRenderPass::getBeginMetadata(
 
 /* See header for details. */
 std::string LCSRenderPass::getContinuationMetadata(
-    const std::string* debugLabel,
+    const std::vector<std::string>* debugLabel,
     uint64_t tagIDContinuation) const
 {
     json metadata = {
@@ -159,7 +159,7 @@ std::string LCSRenderPass::getContinuationMetadata(
 
 /* See header for details. */
 std::string LCSRenderPass::getMetadata(
-    const std::string* debugLabel,
+    const std::vector<std::string>* debugLabel,
     uint64_t tagIDContinuation) const
 {
     if (tagID)
@@ -189,7 +189,7 @@ LCSDispatch::LCSDispatch(
 
 /* See header for details. */
 std::string LCSDispatch::getMetadata(
-    const std::string* debugLabel,
+    const std::vector<std::string>* debugLabel,
     uint64_t tagIDContinuation
 ) const {
     UNUSED(tagIDContinuation);
@@ -227,7 +227,7 @@ LCSTraceRays::LCSTraceRays(
 
 /* See header for details. */
 std::string LCSTraceRays::getMetadata(
-    const std::string* debugLabel,
+    const std::vector<std::string>* debugLabel,
     uint64_t tagIDContinuation
 ) const {
     UNUSED(tagIDContinuation);
@@ -263,9 +263,10 @@ LCSImageTransfer::LCSImageTransfer(
 
 /* See header for details. */
 std::string LCSImageTransfer::getMetadata(
-    const std::string* debugLabel,
+    const std::vector<std::string>* debugLabel,
     uint64_t tagIDContinuation
-) const {
+) const
+{
     UNUSED(tagIDContinuation);
 
     json metadata = {
@@ -298,7 +299,7 @@ LCSBufferTransfer::LCSBufferTransfer(
 
 /* See header for details. */
 std::string LCSBufferTransfer::getMetadata(
-    const std::string* debugLabel,
+    const std::vector<std::string>* debugLabel,
     uint64_t tagIDContinuation
 ) const {
     UNUSED(tagIDContinuation);

--- a/source_common/trackers/layer_command_stream.hpp
+++ b/source_common/trackers/layer_command_stream.hpp
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: MIT
  * ----------------------------------------------------------------------------
- * Copyright (c) 2022-2024 Arm Limited
+ * Copyright (c) 2024-2025 Arm Limited
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to
@@ -28,7 +28,7 @@
  * The declaration of a replayable layer command stream.
  *
  * Role summary
- * ============s
+ * ============
  *
  * These trackers are used to monitor to submission of workloads inside a
  * command buffers in a way that they can be iterated by a queue tracker at
@@ -87,11 +87,11 @@ public:
     /**
      * @brief Get the metadata for this workload
      *
-     * @param debugLabel          The debug label state of the VkQueue at submit time.
+     * @param debugLabel          The debug label stack for the VkQueue at submit time.
      * @param tagIDContinuation   The ID of the workload if this is a continuation of it.
      */
     virtual std::string getMetadata(
-        const std::string* debugLabel=nullptr,
+        const std::vector<std::string>* debugLabel=nullptr,
         uint64_t tagIDContinuation=0) const = 0;
 
     /**
@@ -180,26 +180,26 @@ public:
 
     /* See base class for documentation. */
     virtual std::string getMetadata(
-        const std::string* debugLabel=nullptr,
+        const std::vector<std::string>* debugLabel=nullptr,
         uint64_t tagIDContinuation=0) const;
 
 private:
     /**
      * @brief Get the metadata for this workload if beginning a new render pass.
      *
-     * @param debugLabel   The debug label state of the VkQueue at submit time.
+     * @param debugLabel   The debug label stack of the VkQueue at submit time.
      */
     std::string getBeginMetadata(
-        const std::string* debugLabel=nullptr) const;
+        const std::vector<std::string>* debugLabel=nullptr) const;
 
     /**
      * @brief Get the metadata for this workload if continuing an existing render pass.
      *
-     * @param debugLabel          The debug label state of the VkQueue at submit time.
+     * @param debugLabel          The debug label stack of the VkQueue at submit time.
      * @param tagIDContinuation   The ID of the workload if this is a continuation of it.
      */
     std::string getContinuationMetadata(
-        const std::string* debugLabel=nullptr,
+        const std::vector<std::string>* debugLabel=nullptr,
         uint64_t tagIDContinuation=0) const;
 
     /**
@@ -270,7 +270,7 @@ public:
 
     /* See base class for documentation. */
     virtual std::string getMetadata(
-        const std::string* debugLabel=nullptr,
+        const std::vector<std::string>* debugLabel=nullptr,
         uint64_t tagIDContinuation=0) const;
 
 private:
@@ -319,7 +319,7 @@ public:
 
     /* See base class for documentation. */
     virtual std::string getMetadata(
-        const std::string* debugLabel=nullptr,
+        const std::vector<std::string>* debugLabel=nullptr,
         uint64_t tagIDContinuation=0) const;
 
 private:
@@ -366,7 +366,7 @@ public:
 
     /* See base class for documentation. */
     virtual std::string getMetadata(
-        const std::string* debugLabel=nullptr,
+        const std::vector<std::string>* debugLabel=nullptr,
         uint64_t tagIDContinuation=0) const;
 
 private:
@@ -409,7 +409,7 @@ public:
 
     /* See base class for documentation. */
     virtual std::string getMetadata(
-        const std::string* debugLabel=nullptr,
+        const std::vector<std::string>* debugLabel=nullptr,
         uint64_t tagIDContinuation=0) const;
 
 private:
@@ -448,7 +448,7 @@ public:
 
     /* See base class for documentation. */
     virtual std::string getMetadata(
-        const std::string* debugLabel=nullptr,
+        const std::vector<std::string>* debugLabel=nullptr,
         uint64_t tagIDContinuation=0) const
     {
         UNUSED(debugLabel);

--- a/source_common/trackers/queue.cpp
+++ b/source_common/trackers/queue.cpp
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: MIT
  * ----------------------------------------------------------------------------
- * Copyright (c) 2022-2024 Arm Limited
+ * Copyright (c) 2022-2025 Arm Limited
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to
@@ -61,14 +61,11 @@ void Queue::runSubmitCommandStream(
             auto* workload = dynamic_cast<const LCSRenderPass*>(opData);
             uint64_t tagID = workload->getTagID();
 
-            // Build the debug info
-            std::string log = joinString(debugStack, "|");
-
             // Workload is a new render pass
             if (tagID > 0)
             {
                 assert(lastRenderPassTagID == 0);
-                callback(workload->getMetadata(&log));
+                callback(workload->getMetadata(&debugStack));
 
                 lastRenderPassTagID = 0;
                 if (workload->isSuspending())
@@ -94,7 +91,7 @@ void Queue::runSubmitCommandStream(
         {
             uint64_t tagID = opData->getTagID();
             std::string log = joinString(debugStack, "|");
-            callback(opData->getMetadata(&log, tagID));
+            callback(opData->getMetadata(&debugStack, tagID));
         }
     }
 }


### PR DESCRIPTION
Refactor the user debug label handling to preserve the labels as a list to avoid the need to add character escaping.