### PR TITLE
Android helper script enhancements

### DIFF
--- a/lglpy/android/adb.py
+++ b/lglpy/android/adb.py
@@ -176,7 +176,8 @@ class ADBConnect:
         return rep.stdout
 
     def adb_async(self, *args: str, text: bool = True, shell: bool = False,
-                  quote: bool = False, pipe: bool = False) -> sp.Popen:
+                  quote: bool = False, pipe: bool = False,
+                  filex=None) -> sp.Popen:
         '''
         Call adb to asynchronously run a command, without waiting for it to
         complete.
@@ -196,7 +197,8 @@ class ADBConnect:
             text: True if output is text, False if binary
             shell: True if this should invoke via host shell, False if direct.
             quote: True if arguments are quoted, False if unquoted.
-            pipe: True if child stdout is collected, False if discarded.
+            pipe: True if child stdout is collected to pipe, else False.
+            filex: True if child stdout is collected to file, else False.
 
         Returns:
             The process handle.
@@ -205,7 +207,13 @@ class ADBConnect:
             CalledProcessError: The invoked call failed.
         '''
         # Setup the configuration
-        output = sp.PIPE if pipe else sp.DEVNULL
+        output = sp.DEVNULL
+
+        if pipe:
+            output = sp.PIPE
+
+        if filex:
+            output = filex
 
         # Build the command list
         commands = self.get_base_command(args)

--- a/lglpy/android/perfetto.cfg
+++ b/lglpy/android/perfetto.cfg
@@ -1,0 +1,28 @@
+buffers {
+  size_kb: 65536
+  fill_policy: RING_BUFFER
+}
+
+data_sources: {
+  config {
+    name: "linux.process_stats"
+  }
+}
+
+data_sources: {
+  config {
+    name: "gpu.renderstages"
+  }
+  producer_name_filter: "{{PACKAGE}}"
+}
+
+data_sources: {
+  config {
+    name: "android.surfaceflinger.frametimeline"
+  }
+}
+
+duration_ms: 60000
+write_into_file: true
+file_write_period_ms: 1000
+max_file_size_bytes: 536870912

--- a/lglpy/android/test.py
+++ b/lglpy/android/test.py
@@ -27,7 +27,6 @@ test suite requires an Android device with at least one debuggable application
 installed to be connected to the host PC with an authorized adb connection.
 '''
 
-import contextlib
 import os
 import re
 import shutil
@@ -37,7 +36,7 @@ import tempfile
 import unittest
 
 from .adb import ADBConnect
-from .utils import AndroidUtils
+from .utils import AndroidUtils, NamedTempFile
 from .filesystem import AndroidFilesystem
 
 
@@ -56,30 +55,6 @@ def get_script_relative_path(file_name: str) -> str:
     '''
     dir_name = os.path.dirname(__file__)
     return os.path.join(dir_name, file_name)
-
-
-@contextlib.contextmanager
-def NamedTempFile():  # pylint: disable=invalid-name
-    '''
-    Creates a context managed temporary file that can be used with external
-    subprocess.
-
-    On context entry this yields the file name, on exit it deletes the file.
-
-    Yields:
-        The name of the temporary file.
-    '''
-    name = None
-
-    try:
-        f = tempfile.NamedTemporaryFile(delete=False)
-        name = f.name
-        f.close()
-        yield name
-
-    finally:
-        if name:
-            os.unlink(name)
 
 
 class AndroidTestNoDevice(unittest.TestCase):

--- a/lglpy/android/utils.py
+++ b/lglpy/android/utils.py
@@ -26,12 +26,42 @@ This module implements higher level Android queries and utility functions,
 built on top of the low level ADBConnect wrapper around Android Debug Bridge.
 '''
 
+import contextlib
 import re
+import os
 import shlex
 import subprocess as sp
+import tempfile
 from typing import Optional
 
 from .adb import ADBConnect
+
+
+@contextlib.contextmanager
+def NamedTempFile(suffix=None):  # pylint: disable=invalid-name
+    '''
+    Creates a context managed temporary file that can be used with external
+    subprocess.
+
+    On context entry this yields the file name, on exit it deletes the file.
+
+    Args:
+        suffix: An optional file suffix.
+
+    Yields:
+        The name of the temporary file.
+    '''
+    name = None
+
+    try:
+        f = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+        name = f.name
+        f.close()
+        yield name
+
+    finally:
+        if name:
+            os.unlink(name)
 
 
 class AndroidUtils:

--- a/lglpy/comms/service_gpu_timeline.py
+++ b/lglpy/comms/service_gpu_timeline.py
@@ -29,9 +29,17 @@ frame records to a file on the host.
 
 import json
 import struct
-from typing import Any
+from typing import Any, TypedDict
 
 from lglpy.comms.server import Message
+
+
+class FrameMetadataType(TypedDict):
+    '''
+    Structured dict type for type hinting.
+    '''
+    frame: int
+    workloads: list[Any]
 
 
 class GPUTimelineService:
@@ -39,22 +47,24 @@ class GPUTimelineService:
     A service for handling network comms from the layer_gpu_timeline layer.
     '''
 
-    def __init__(self):
+    def __init__(self, file_path: str):
         '''
         Initialize the timeline service.
+
+        Args:
+            file_path: File to write on the filesystem
 
         Returns:
             The endpoint name.
         '''
         # Create a default frame record
-        self.frame = {
-            "frame": 0,
-            "workloads": []
+        self.frame: FrameMetadataType = {
+            'frame': 0,
+            'workloads': []
         }
 
-        # TODO: Make file name configurable
         # pylint: disable=consider-using-with
-        self.file_handle = open('malivision.gputl', 'wb')
+        self.file_handle = open(file_path, 'wb')
 
     def get_service_name(self) -> str:
         '''


### PR DESCRIPTION
Improve the Android helper scripts to perform more setup to support development.

* Server script can now automatically setup adb reverse.
* Server script now optionally captures metadata traces for Mali timeline layer.
* Install script can now automatically capture logcat logs.
* Install script can now automatically capture Perfetto traces for Mali timeline layer.
