### PR TITLE
Remove vkEnumerateInstanceExtensionProperties from instance dispatch

### DIFF
--- a/generator/generate_vulkan_common.py
+++ b/generator/generate_vulkan_common.py
@@ -48,7 +48,7 @@ NO_INTERCEPT_OR_DISPATCH_FUNCTIONS = {
 
 # These functions are excluded from generated intercept tables
 NO_INTERCEPT_FUNCTIONS = {
-    # Functions exported as shared object exports and resolved by loader
+    # Functions exported as shared object symbols and resolved by loader
     'vkEnumerateDeviceExtensionProperties',
     'vkEnumerateDeviceLayerProperties',
     'vkEnumerateInstanceExtensionProperties',
@@ -57,9 +57,10 @@ NO_INTERCEPT_FUNCTIONS = {
 
 # These functions are excluded from generated dispatch tables
 NO_DISPATCH_FUNCTIONS = {
-    # Functions resolved by the loaded not the implementation
+    # Functions resolved by the loader not the implementation
     'vkCreateDevice',
     'vkCreateInstance',
+    'vkEnumerateInstanceExtensionProperties',
 }
 
 # These functions are excluded from generated declarations

--- a/source_common/framework/instance_dispatch_table.hpp
+++ b/source_common/framework/instance_dispatch_table.hpp
@@ -605,7 +605,6 @@ struct InstanceDispatchTable {
     PFN_vkDestroySurfaceKHR vkDestroySurfaceKHR;
     PFN_vkEnumerateDeviceExtensionProperties vkEnumerateDeviceExtensionProperties;
     PFN_vkEnumerateDeviceLayerProperties vkEnumerateDeviceLayerProperties;
-    PFN_vkEnumerateInstanceExtensionProperties vkEnumerateInstanceExtensionProperties;
     PFN_vkEnumerateInstanceLayerProperties vkEnumerateInstanceLayerProperties;
     PFN_vkEnumeratePhysicalDeviceGroups vkEnumeratePhysicalDeviceGroups;
     PFN_vkEnumeratePhysicalDeviceGroupsKHR vkEnumeratePhysicalDeviceGroupsKHR;
@@ -697,7 +696,6 @@ static inline void initDriverInstanceDispatchTable(
     ENTRY(vkDestroySurfaceKHR);
     ENTRY(vkEnumerateDeviceExtensionProperties);
     ENTRY(vkEnumerateDeviceLayerProperties);
-    ENTRY(vkEnumerateInstanceExtensionProperties);
     ENTRY(vkEnumerateInstanceLayerProperties);
     ENTRY(vkEnumeratePhysicalDeviceGroups);
     ENTRY(vkEnumeratePhysicalDeviceGroupsKHR);


### PR DESCRIPTION
vkEnumerateInstanceExtensionProperties is resolved by the loader, so 
do not dynamically query the instance to add it to the instance 
dispatch table.