### PR TITLE
Workaround pre-instance functions on Android

### DIFF
--- a/generator/generate_vulkan_common.py
+++ b/generator/generate_vulkan_common.py
@@ -48,7 +48,7 @@ NO_INTERCEPT_OR_DISPATCH_FUNCTIONS = {
 
 # These functions are excluded from generated intercept tables
 NO_INTERCEPT_FUNCTIONS = {
-    # Functions exported as shared object exports and resolved by loader
+    # Functions exported as shared object symbols and resolved by loader
     'vkEnumerateDeviceExtensionProperties',
     'vkEnumerateDeviceLayerProperties',
     'vkEnumerateInstanceExtensionProperties',
@@ -57,9 +57,10 @@ NO_INTERCEPT_FUNCTIONS = {
 
 # These functions are excluded from generated dispatch tables
 NO_DISPATCH_FUNCTIONS = {
-    # Functions resolved by the loaded not the implementation
+    # Functions resolved by the loader not the implementation
     'vkCreateDevice',
     'vkCreateInstance',
+    'vkEnumerateInstanceExtensionProperties',
 }
 
 # These functions are excluded from generated declarations

--- a/source_common/framework/instance_dispatch_table.hpp
+++ b/source_common/framework/instance_dispatch_table.hpp
@@ -605,7 +605,6 @@ struct InstanceDispatchTable {
     PFN_vkDestroySurfaceKHR vkDestroySurfaceKHR;
     PFN_vkEnumerateDeviceExtensionProperties vkEnumerateDeviceExtensionProperties;
     PFN_vkEnumerateDeviceLayerProperties vkEnumerateDeviceLayerProperties;
-    PFN_vkEnumerateInstanceExtensionProperties vkEnumerateInstanceExtensionProperties;
     PFN_vkEnumerateInstanceLayerProperties vkEnumerateInstanceLayerProperties;
     PFN_vkEnumeratePhysicalDeviceGroups vkEnumeratePhysicalDeviceGroups;
     PFN_vkEnumeratePhysicalDeviceGroupsKHR vkEnumeratePhysicalDeviceGroupsKHR;
@@ -697,7 +696,6 @@ static inline void initDriverInstanceDispatchTable(
     ENTRY(vkDestroySurfaceKHR);
     ENTRY(vkEnumerateDeviceExtensionProperties);
     ENTRY(vkEnumerateDeviceLayerProperties);
-    ENTRY(vkEnumerateInstanceExtensionProperties);
     ENTRY(vkEnumerateInstanceLayerProperties);
     ENTRY(vkEnumeratePhysicalDeviceGroups);
     ENTRY(vkEnumeratePhysicalDeviceGroupsKHR);

--- a/source_common/framework/manual_functions.cpp
+++ b/source_common/framework/manual_functions.cpp
@@ -463,8 +463,9 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateInstance_default(
     //
     // On Android if you call chainInfo getInstanceProcAddr() to get the function in the next layer
     // you will get the layer implementation of the function, and layer implementations of this
-    // function will return functions that they implement and not forward to the driver. Any query
-    // for anything other than the layer will just return VK_ERROR_LAYER_NOT_PRESENT.
+    // function will return the additional extensions that the layer itself provides. It does not
+    // forward to the driver, and any query for anything other than the layer will just return
+    // VK_ERROR_LAYER_NOT_PRESENT.
     //
     // If you are running with a single layer you can set this to true, and use proper queries.
     constexpr bool queryExtensions = false;

--- a/source_common/framework/manual_functions.cpp
+++ b/source_common/framework/manual_functions.cpp
@@ -456,11 +456,29 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateInstance_default(
 ) {
     LAYER_TRACE(__func__);
 
-    auto* chainInfo = getChainInfo(pCreateInfo);
-    auto supportedExtensions = getInstanceExtensionList(pCreateInfo);
+    // We cannot reliably query the available instance extensions on Android if multiple layers are
+    // installed, so we disable this by default. This occurs because Android only implements the v0
+    // specification between the loader and the interceptor, and does not implement chainable
+    // intercepts for vkEnumerateInstanceExtensionProperties().
+    //
+    // On Android if you call chainInfo getInstanceProcAddr() to get the function in the next layer
+    // you will get the layer implementation of the function, and layer implementations of this
+    // function will return functions that they implement and not forward to the driver. Any query
+    // for anything other than the layer will just return VK_ERROR_LAYER_NOT_PRESENT.
+    //
+    // If you are running with a single layer you can set this to true, and use proper queries.
+    constexpr bool queryExtensions = false;
 
+    std::vector<std::string> supportedExtensions;
+    if (queryExtensions)
+    {
+        supportedExtensions = getInstanceExtensionList(pCreateInfo);
+    }
+
+    auto* chainInfo = getChainInfo(pCreateInfo);
     auto fpGetInstanceProcAddr = chainInfo->u.pLayerInfo->pfnNextGetInstanceProcAddr;
-    auto fpCreateInstance = reinterpret_cast<PFN_vkCreateInstance>(fpGetInstanceProcAddr(nullptr, "vkCreateInstance"));
+    auto fpCreateInstanceRaw = fpGetInstanceProcAddr(nullptr, "vkCreateInstance");
+    auto fpCreateInstance = reinterpret_cast<PFN_vkCreateInstance>(fpCreateInstanceRaw);
     if (!fpCreateInstance)
     {
         return VK_ERROR_INITIALIZATION_FAILED;
@@ -471,7 +489,13 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateInstance_default(
 
     // Query extension state
     std::string targetExt("VK_EXT_debug_utils");
-    bool targetSupported = isIn(targetExt, supportedExtensions);
+    // Assume common extensions are available (see comment at start of function)
+    bool targetSupported = true;
+    if (queryExtensions)
+    {
+        targetSupported = isIn(targetExt, supportedExtensions);
+    }
+
     bool targetEnabled = isInExtensionList(
         targetExt,
         pCreateInfo->enabledExtensionCount,

--- a/source_common/framework/manual_functions.hpp
+++ b/source_common/framework/manual_functions.hpp
@@ -112,6 +112,11 @@ PFN_vkVoidFunction getDeviceLayerFunction(
 /**
  * @brief Fetch the list of supported extensions from the instance.
  *
+ * WARNING: This function only works on Android and only works for the bottom
+ * layer in a stack. Layers higher up the stack are likely to crash, and there
+ * is no workaround because the the Android loader doesn't implement chainable
+ * queries for pre-instance functions.
+ *
  * @param pCreateInfo   The instance creation data from the loader.
  *
  * @return The list of supported extensions; empty list on failure.


### PR DESCRIPTION
Pre-instance functions are not supposed to be intercepted, but Android 
doesn't implement the better interface for chainable pre-instance 
functions. Trying to intercept the vkEnumerateInstanceExtensionProperties
so a layer can query what extensions are available will not work
for any layer other than the bottom layer in the stack. 

If you have multiple layers in installed, the higher layers will try 
to use vkGetInstanceProcAddr to get the function in the next layer
down and get the stub implementation for the extensions the layer
itself implements without reaching the driver.