### PR TITLE
Pass device CreateInfo to Device

### DIFF
--- a/generator/vk_layer/source/device.cpp
+++ b/generator/vk_layer/source/device.cpp
@@ -90,11 +90,14 @@ Device::Device(
     Instance* _instance,
     VkPhysicalDevice _physicalDevice,
     VkDevice _device,
-    PFN_vkGetDeviceProcAddr nlayerGetProcAddress
+    PFN_vkGetDeviceProcAddr nlayerGetProcAddress,
+    const VkDeviceCreateInfo& createInfo
 ):
     instance(_instance),
     physicalDevice(_physicalDevice),
     device(_device)
 {
+    UNUSED(createInfo);
+
     initDriverDeviceDispatchTable(device, nlayerGetProcAddress, driver);
 }

--- a/generator/vk_layer/source/device.hpp
+++ b/generator/vk_layer/source/device.hpp
@@ -115,16 +115,20 @@ public:
     /**
      * @brief Create a new layer device object.
      *
+     * Create info is transient, so the constructor must copy what it needs.
+     *
      * @param instance               The layer instance object this device is created with.
      * @param physicalDevice         The physical device this logical device is for.
      * @param device                 The device handle this device is created with.
      * @param nlayerGetProcAddress   The vkGetProcAddress function in the driver/next layer down.
+     * @param createInfo             The create info used to create the device.
      */
     Device(
         Instance* instance,
         VkPhysicalDevice physicalDevice,
         VkDevice device,
-        PFN_vkGetDeviceProcAddr nlayerGetProcAddress);
+        PFN_vkGetDeviceProcAddr nlayerGetProcAddress,
+        const VkDeviceCreateInfo& createInfo);
 
     /**
      * @brief Destroy this layer device object.

--- a/layer_example/source/device.cpp
+++ b/layer_example/source/device.cpp
@@ -90,11 +90,14 @@ Device::Device(
     Instance* _instance,
     VkPhysicalDevice _physicalDevice,
     VkDevice _device,
-    PFN_vkGetDeviceProcAddr nlayerGetProcAddress
+    PFN_vkGetDeviceProcAddr nlayerGetProcAddress,
+    const VkDeviceCreateInfo& createInfo
 ):
     instance(_instance),
     physicalDevice(_physicalDevice),
     device(_device)
 {
+    UNUSED(createInfo);
+
     initDriverDeviceDispatchTable(device, nlayerGetProcAddress, driver);
 }

--- a/layer_example/source/device.hpp
+++ b/layer_example/source/device.hpp
@@ -115,16 +115,20 @@ public:
     /**
      * @brief Create a new layer device object.
      *
+     * Create info is transient, so the constructor must copy what it needs.
+     *
      * @param instance               The layer instance object this device is created with.
      * @param physicalDevice         The physical device this logical device is for.
      * @param device                 The device handle this device is created with.
      * @param nlayerGetProcAddress   The vkGetProcAddress function in the driver/next layer down.
+     * @param createInfo             The create info used to create the device.
      */
     Device(
         Instance* instance,
         VkPhysicalDevice physicalDevice,
         VkDevice device,
-        PFN_vkGetDeviceProcAddr nlayerGetProcAddress);
+        PFN_vkGetDeviceProcAddr nlayerGetProcAddress,
+        const VkDeviceCreateInfo& createInfo);
 
     /**
      * @brief Destroy this layer device object.

--- a/layer_gpu_support/source/device.cpp
+++ b/layer_gpu_support/source/device.cpp
@@ -35,7 +35,7 @@ static std::unordered_map<void*, std::unique_ptr<Device>> g_devices;
 
 /* See header for documentation. */
 const std::vector<std::string> Device::extraExtensions {
-    "VK_KHR_timeline_semaphore"
+    VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME
 };
 
 /* See header for documentation. */
@@ -86,12 +86,15 @@ Device::Device(
     Instance* _instance,
     VkPhysicalDevice _physicalDevice,
     VkDevice _device,
-    PFN_vkGetDeviceProcAddr nlayerGetProcAddress
+    PFN_vkGetDeviceProcAddr nlayerGetProcAddress,
+    const VkDeviceCreateInfo& createInfo
 ):
     instance(_instance),
     physicalDevice(_physicalDevice),
     device(_device)
 {
+    UNUSED(createInfo);
+
     initDriverDeviceDispatchTable(device, nlayerGetProcAddress, driver);
 
     VkSemaphoreTypeCreateInfo timelineCreateInfo {
@@ -101,14 +104,14 @@ Device::Device(
         .initialValue = queueSerializationTimelineSemCount
     };
 
-    VkSemaphoreCreateInfo createInfo {
+    VkSemaphoreCreateInfo semCreateInfo {
         .sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
         .pNext = &timelineCreateInfo,
         .flags = 0
     };
 
     auto result = driver.vkCreateSemaphore(
-        device, &createInfo, nullptr, &queueSerializationTimelineSem);
+        device, &semCreateInfo, nullptr, &queueSerializationTimelineSem);
     if (result != VK_SUCCESS)
     {
         LAYER_ERR("Failed vkCreateSemaphore() for queue serialization");

--- a/layer_gpu_support/source/device.hpp
+++ b/layer_gpu_support/source/device.hpp
@@ -115,16 +115,20 @@ public:
     /**
      * @brief Create a new layer device object.
      *
+     * Create info is transient, so the constructor must copy what it needs.
+     *
      * @param instance               The layer instance object this device is created with.
      * @param physicalDevice         The physical device this logical device is for.
      * @param device                 The device handle this device is created with.
      * @param nlayerGetProcAddress   The vkGetProcAddress function in the driver/next layer down.
+     * @param createInfo             The create info used to create the device.
      */
     Device(
         Instance* instance,
         VkPhysicalDevice physicalDevice,
         VkDevice device,
-        PFN_vkGetDeviceProcAddr nlayerGetProcAddress);
+        PFN_vkGetDeviceProcAddr nlayerGetProcAddress,
+        const VkDeviceCreateInfo& createInfo);
 
     /**
      * @brief Destroy this layer device object.

--- a/layer_gpu_timeline/source/device.cpp
+++ b/layer_gpu_timeline/source/device.cpp
@@ -97,12 +97,15 @@ Device::Device(
     Instance* _instance,
     VkPhysicalDevice _physicalDevice,
     VkDevice _device,
-    PFN_vkGetDeviceProcAddr nlayerGetProcAddress
+    PFN_vkGetDeviceProcAddr nlayerGetProcAddress,
+    const VkDeviceCreateInfo& createInfo
 ):
     instance(_instance),
     physicalDevice(_physicalDevice),
     device(_device)
 {
+    UNUSED(createInfo);
+
     initDriverDeviceDispatchTable(device, nlayerGetProcAddress, driver);
 
     // Init the shared comms module for the first device built

--- a/layer_gpu_timeline/source/device.hpp
+++ b/layer_gpu_timeline/source/device.hpp
@@ -118,16 +118,20 @@ public:
     /**
      * @brief Create a new layer device object.
      *
+     * Create info is transient, so the constructor must copy what it needs.
+     *
      * @param instance               The layer instance object this device is created with.
      * @param physicalDevice         The physical device this logical device is for.
      * @param device                 The device handle this device is created with.
      * @param nlayerGetProcAddress   The vkGetDeviceProcAddress function for the driver.
+     * @param createInfo             The create info used to create the device.
      */
     Device(
         Instance* instance,
         VkPhysicalDevice physicalDevice,
         VkDevice device,
-        PFN_vkGetDeviceProcAddr nlayerGetProcAddress);
+        PFN_vkGetDeviceProcAddr nlayerGetProcAddress,
+        const VkDeviceCreateInfo& createInfo);
 
     /**
      * @brief Destroy this layer device object.

--- a/source_common/comms/CMakeLists.txt
+++ b/source_common/comms/CMakeLists.txt
@@ -32,7 +32,8 @@ add_library(
 
 target_include_directories(
     ${LIB_BINARY} PRIVATE
-        ../)
+        ../
+        ../../source_third_party/khronos/vulkan/include/)
 
 lgl_set_build_options(${LIB_BINARY})
 

--- a/source_common/framework/CMakeLists.txt
+++ b/source_common/framework/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: MIT
 # -----------------------------------------------------------------------------
-# Copyright (c) 2024 Arm Limited
+# Copyright (c) 2024-2025 Arm Limited
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to
@@ -26,6 +26,7 @@ set(LIB_BINARY lib_layer_framework)
 add_library(
     ${LIB_BINARY} STATIC
         device_functions.cpp
+        device_query.cpp
         instance_functions.cpp
         manual_functions.cpp)
 

--- a/source_common/framework/device_query.cpp
+++ b/source_common/framework/device_query.cpp
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * ----------------------------------------------------------------------------
+ * Copyright (c) 2025 Arm Limited
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ * ----------------------------------------------------------------------------
+ */
+
+#include <vulkan/vulkan.h>
+
+#include "utils/misc.hpp"
+
+/** See header for documentation. */
+bool isEnabledVkKhrTimelineSemaphore(
+    const VkDeviceCreateInfo& createInfo
+) {
+    // Check Vulkan 1.2 core feature first
+    auto* coreFeature = searchNextList<VkPhysicalDeviceVulkan12Features>(
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES,
+        createInfo.pNext);
+    if (coreFeature)
+    {
+        return coreFeature->timelineSemaphore;
+    }
+
+    // Check the extension second
+    bool extEnabled = isInExtensionList(
+      VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME,
+      createInfo.enabledExtensionCount,
+      createInfo.ppEnabledExtensionNames);
+    if (!extEnabled)
+    {
+        return false;
+    }
+
+    auto* extFeature = searchNextList<VkPhysicalDeviceTimelineSemaphoreFeatures>(
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES,
+        createInfo.pNext);
+    if (extFeature)
+    {
+        return extFeature->timelineSemaphore;
+    }
+
+    return false;
+}

--- a/source_common/framework/device_query.hpp
+++ b/source_common/framework/device_query.hpp
@@ -42,34 +42,4 @@
  * @return @c true if enabled, @c false otherwise.
  */
 bool isEnabledVkKhrTimelineSemaphore(
-    const VkDeviceCreateInfo& createInfo
-) {
-    // Check Vulkan 1.2 core feature first
-    auto* coreFeature = searchNextList<VkPhysicalDeviceVulkan12Features>(
-        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES,
-        createInfo.pNext);
-    if (coreFeature)
-    {
-        return coreFeature->timelineSemaphore;
-    }
-
-    // Check the extension second
-    bool extEnabled = isInExtensionList(
-      VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME,
-      createInfo.enabledExtensionCount,
-      createInfo.ppEnabledExtensionNames);
-    if (!extEnabled)
-    {
-        return false;
-    }
-
-    auto* extFeature = searchNextList<VkPhysicalDeviceTimelineSemaphoreFeatures>(
-        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES,
-        createInfo.pNext);
-    if (extFeature)
-    {
-        return extFeature->timelineSemaphore;
-    }
-
-    return false;
-}
+    const VkDeviceCreateInfo& createInfo0);

--- a/source_common/framework/device_query.hpp
+++ b/source_common/framework/device_query.hpp
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * ----------------------------------------------------------------------------
+ * Copyright (c) 2025 Arm Limited
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ * ----------------------------------------------------------------------------
+ */
+
+/**
+ * @file
+ * This module implements device property query functions.
+ */
+
+#pragma once
+
+#include <vulkan/vulkan.h>
+
+#include "utils/misc.hpp"
+
+/**
+ * Test if VK_KHR_timeline_semaphore (or equivalent core feature) is enabled.
+ *
+ * @param createInfo   The device creation configuration.
+ *
+ * @return @c true if enabled, @c false otherwise.
+ */
+bool isEnabledVkKhrTimelineSemaphore(
+    const VkDeviceCreateInfo& createInfo
+) {
+    // Check Vulkan 1.2 core feature first
+    auto* coreFeature = searchNextList<VkPhysicalDeviceVulkan12Features>(
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES,
+        createInfo.pNext);
+    if (coreFeature)
+    {
+        return coreFeature->timelineSemaphore;
+    }
+
+    // Check the extension second
+    bool extEnabled = isInExtensionList(
+      VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME,
+      createInfo.enabledExtensionCount,
+      createInfo.ppEnabledExtensionNames);
+    if (!extEnabled)
+    {
+        return false;
+    }
+
+    auto* extFeature = searchNextList<VkPhysicalDeviceTimelineSemaphoreFeatures>(
+        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES,
+        createInfo.pNext);
+    if (extFeature)
+    {
+        return extFeature->timelineSemaphore;
+    }
+
+    return false;
+}

--- a/source_common/framework/manual_functions.hpp
+++ b/source_common/framework/manual_functions.hpp
@@ -185,20 +185,6 @@ std::vector<std::string> getDeviceExtensionList(
     const VkDeviceCreateInfo* pCreateInfo);
 
 /**
- * @brief Is an extension in the passed extension list.
- *
- * @param target           The target extension to look for.
- * @param extensionCount   The number of extensions in the list.
- * @param extensionList    The list of extensions.
- *
- * @return @c true if @c target is found in @c extensionList.
- */
-bool isInExtensionList(
-    std::string target,
-    uint32_t extensionCount,
-    const char* const* extensionList);
-
-/**
  * @brief Clone the target extension list.
  *
  * @param extensionCount   The number of extensions in the list.

--- a/source_common/utils/misc.hpp
+++ b/source_common/utils/misc.hpp
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: MIT
  * ----------------------------------------------------------------------------
- * Copyright (c) 2022-2024 Arm Limited
+ * Copyright (c) 2022-2025 Arm Limited
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to
@@ -36,6 +36,8 @@
 #include <sstream>
 #include <string>
 #include <vector>
+
+#include <vulkan/vulkan.h>
 
 /**
  * @brief Macro to stringize a value.
@@ -144,6 +146,54 @@ void vecAppend(
 
     // Merge secondary into this command buffer
     dst.insert(std::end(dst), std::begin(src), std::end(src));
+}
+
+/**
+ * @brief Is an extension in the passed extension list.
+ *
+ * @param target           The target extension to look for.
+ * @param extensionCount   The number of extensions in the list.
+ * @param extensionList    The list of extensions.
+ *
+ * @return @c true if @c target is found in @c extensionList.
+ */
+static inline bool isInExtensionList(
+    std::string target,
+    uint32_t extensionCount,
+    const char* const* extensionList
+) {
+    for(uint32_t i = 0; i < extensionCount; i++)
+    {
+        if (target == extensionList[i])
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * @brief Helper to search a Vulkan "pNext" list for a matching structure.
+ */
+template <typename T>
+T* searchNextList(
+    VkStructureType sType,
+    const void* pNext
+) {
+    const auto* pStruct = reinterpret_cast<const T*>(pNext);
+    while(pStruct)
+    {
+        if (pStruct->sType == sType)
+        {
+            break;
+        }
+        pStruct = reinterpret_cast<const T*>(pStruct->pNext);
+    }
+
+    // Const cast is not ideal here but we don't have functionality to
+    // clone a writable copy of the entire pNext chain yet ...
+    return const_cast<T*>(pStruct);
 }
 
 /**

--- a/source_common/utils/misc.hpp
+++ b/source_common/utils/misc.hpp
@@ -33,6 +33,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cinttypes>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>


### PR DESCRIPTION
Device instances need to know how the underlying Vulkan 
instance was constructed, for example what extensions and
features are available. 

Passing the CreateInfo to the device allows the constructor
to extract what it needs.