### PR TITLE
Emit queue-level metadata as part of the timeline layer

### DIFF
--- a/lglpy/comms/service_gpu_timeline.py
+++ b/lglpy/comms/service_gpu_timeline.py
@@ -34,12 +34,21 @@ from typing import Any, TypedDict
 from lglpy.comms.server import Message
 
 
+class SubmitMetadataType(TypedDict):
+    '''
+    Structured dict type for type hinting.
+    '''
+    queue: int
+    timestamp: int
+    workloads: list[Any]
+
+
 class FrameMetadataType(TypedDict):
     '''
     Structured dict type for type hinting.
     '''
     frame: int
-    workloads: list[Any]
+    submits: list[SubmitMetadataType]
 
 
 class GPUTimelineService:
@@ -102,7 +111,6 @@ class GPUTimelineService:
         if next_frame % 100 == 0:
             print(f'Starting frame {next_frame} ...')
 
-
     def handle_submit(self, msg: Any) -> None:
         '''
         Handle a submit boundary workload.
@@ -111,7 +119,7 @@ class GPUTimelineService:
             msg: The Python decode of a JSON payload.
         '''
         # Write frame packet to the file
-        submit = {
+        submit: SubmitMetadataType = {
             'queue': msg['queue'],
             'timestamp': msg['timestamp'],
             'workloads': []

--- a/lglpy/comms/service_gpu_timeline.py
+++ b/lglpy/comms/service_gpu_timeline.py
@@ -60,7 +60,7 @@ class GPUTimelineService:
         # Create a default frame record
         self.frame: FrameMetadataType = {
             'frame': 0,
-            'workloads': []
+            'submits': []
         }
 
         # pylint: disable=consider-using-with
@@ -96,11 +96,29 @@ class GPUTimelineService:
         next_frame = msg['fid']
         self.frame = {
             'frame': next_frame,
-            'workloads': []
+            'submits': []
         }
 
         if next_frame % 100 == 0:
             print(f'Starting frame {next_frame} ...')
+
+
+    def handle_submit(self, msg: Any) -> None:
+        '''
+        Handle a submit boundary workload.
+
+        Args:
+            msg: The Python decode of a JSON payload.
+        '''
+        # Write frame packet to the file
+        submit = {
+            'queue': msg['queue'],
+            'timestamp': msg['timestamp'],
+            'workloads': []
+        }
+
+        # Reset the local frame state for the next frame
+        self.frame['submits'].append(submit)
 
     def handle_render_pass(self, msg: Any) -> None:
         '''
@@ -113,10 +131,12 @@ class GPUTimelineService:
         Args:
             msg: The Python decode of a JSON payload.
         '''
+        submit = self.frame['submits'][-1]
+
         # Find the last workload
         last_render_pass = None
-        if self.frame['workloads']:
-            last_workload = self.frame['workloads'][-1]
+        if submit['workloads']:
+            last_workload = submit['workloads'][-1]
             if last_workload['type'] == 'renderpass':
                 last_render_pass = last_workload
 
@@ -128,7 +148,7 @@ class GPUTimelineService:
 
         # Otherwise this is a new record
         else:
-            self.frame['workloads'].append(msg)
+            submit['workloads'].append(msg)
 
     def handle_generic(self, msg: Any) -> None:
         '''
@@ -137,7 +157,8 @@ class GPUTimelineService:
         Args:
             msg: The Python decode of a JSON payload.
         '''
-        self.frame['workloads'].append(msg)
+        submit = self.frame['submits'][-1]
+        submit['workloads'].append(msg)
 
     def handle_message(self, message: Message) -> None:
         '''
@@ -160,6 +181,9 @@ class GPUTimelineService:
 
         if payload_type == 'frame':
             self.handle_frame(payload)
+
+        elif payload_type == 'submit':
+            self.handle_submit(payload)
 
         elif payload_type == 'renderpass':
             self.handle_render_pass(payload)

--- a/lglpy/timeline/data/processed_trace.py
+++ b/lglpy/timeline/data/processed_trace.py
@@ -66,6 +66,7 @@ class GPUWorkload:
             metadata: Parsed metadata annotation.
         '''
         # Common data we from the Perfetto event
+        self.submit_id = event.submit_id
         self.tag_id = event.user_label
         self.start_time = event.start_time
         self.duration = event.duration
@@ -175,8 +176,9 @@ class GPUWorkload:
         Returns:
             Returns the label for use in the UI.
         '''
-        assert False, 'Subclass must implement this'
-        return ''
+        # Subclass will override this if metadata exists
+        # Submit ID isn't useful, but traces back to Perfetto data for debug
+        return f'Submit: {self.submit_id}'
 
     def get_short_label(self) -> str:
         '''
@@ -185,8 +187,9 @@ class GPUWorkload:
         Returns:
             Returns the label for use in the UI.
         '''
-        assert False, 'Subclass must implement this'
-        return ''
+        # Subclass will override this if metadata exists
+        # Submit ID isn't useful, but traces back to Perfetto data for debug
+        return f'Submit: {self.submit_id}'
 
 
 class GPURenderPass(GPUWorkload):

--- a/lglpy/timeline/data/raw_trace.py
+++ b/lglpy/timeline/data/raw_trace.py
@@ -358,6 +358,10 @@ class RenderstageEvent:
         self.start_time = start_time
         self.duration = int(spec.duration)
 
+        self.submit_id = None
+        if spec.HasField('submission_id'):
+            self.submit_id = spec.submission_id
+
         # Decode the interned stream and stage types
         # Interning is resolved later as packets may be out-of-order
         self.stream_iid = int(spec.hw_queue_iid)

--- a/lglpy/timeline/drawable/world_drawable.py
+++ b/lglpy/timeline/drawable/world_drawable.py
@@ -130,7 +130,7 @@ class WorldDrawableRect(WorldDrawable):
         # Draw label if present and above minimal size
         if self.style.bind_font(gc):
             # Try the full label
-            if self.label.fits_centered(gc, w, 4):
+            if self.label and self.label.fits_centered(gc, w, 4):
                 self.label.draw_centered(gc, (x, y), (w, h))
             elif self.label_short and self.label_short.fits_centered(gc, w, 4):
                 self.label_short.draw_centered(gc, (x, y), (w, h))


### PR DESCRIPTION
Adds a per-submit metadata packet about the submit itself, 
rather than the command buffers it contains. This includes
the submit time (clock_monotonic_raw) and queue handle.

Each submit will emit the submit data packet and then zero or
more command buffer data packets immediately afterwards.
