### PR TITLE
Allow installer to collect timeline metadata

### DIFF
--- a/lgl_host_server.py
+++ b/lgl_host_server.py
@@ -96,7 +96,7 @@ def main() -> int:
     print(f'  - [{endpoint_id}] = {service.get_service_name()}')
 
     if args.timeline:
-        service = service_gpu_timeline.GPUTimelineService(args.timeline)
+        service = service_gpu_timeline.GPUTimelineService(args.timeline, True)
         endpoint_id = svr.register_endpoint(service)
         print(f'  - [{endpoint_id}] = {service.get_service_name()}')
 

--- a/lglpy/comms/server.py
+++ b/lglpy/comms/server.py
@@ -160,13 +160,15 @@ class CommsServer:
         shutdown Flag fro tracking shutdown status.
     '''
 
-    def __init__(self, port: int):
+    def __init__(self, port: int, verbose: bool = False):
         '''
         Construct, but do not start, a server instance.
 
         Args:
             port: The local TCP/IP port to listen on.
+            verbose: Should this use verbose logging?
         '''
+        self.verbose = verbose
         self.endpoints = {}  # type: dict[int, Any]
         self.register_endpoint(self)
 
@@ -230,19 +232,23 @@ class CommsServer:
         '''
         # Accept a new client connection and assign a data socket
         while not self.shutdown:
-            print('Waiting for client connection')
+            if self.verbose:
+                print('Waiting for client connection')
             try:
                 self.sockd, _ = self.sockl.accept()
-                print('  + Client connected')
+                if self.verbose:
+                    print('  + Client connected')
 
                 self.run_client()
 
-                print('  + Client disconnected')
+                if self.verbose:
+                    print('  + Client disconnected')
                 self.sockd.close()
                 self.sockd = None
 
             except ClientDropped:
-                print('  + Client disconnected')
+                if self.verbose:
+                    print('  + Client disconnected')
                 if self.sockd:
                     self.sockd.close()
                     self.sockd = None

--- a/lglpy/comms/service_gpu_timeline.py
+++ b/lglpy/comms/service_gpu_timeline.py
@@ -56,12 +56,13 @@ class GPUTimelineService:
     A service for handling network comms from the layer_gpu_timeline layer.
     '''
 
-    def __init__(self, file_path: str):
+    def __init__(self, file_path: str, verbose: bool = False):
         '''
         Initialize the timeline service.
 
         Args:
             file_path: File to write on the filesystem
+            verbose: Should this use verbose logging?
 
         Returns:
             The endpoint name.
@@ -74,6 +75,7 @@ class GPUTimelineService:
 
         # pylint: disable=consider-using-with
         self.file_handle = open(file_path, 'wb')
+        self.verbose = verbose
 
     def get_service_name(self) -> str:
         '''
@@ -96,8 +98,9 @@ class GPUTimelineService:
         minor = msg["driverMinor"]
         patch = msg["driverPatch"]
 
-        print(f'Device: {msg["deviceName"]}')
-        print(f'Driver: r{major}p{minor} ({patch})')
+        if self.verbose:
+            print(f'Device: {msg["deviceName"]}')
+            print(f'Driver: r{major}p{minor} ({patch})')
 
     def handle_frame(self, msg: Any) -> None:
         '''
@@ -123,7 +126,7 @@ class GPUTimelineService:
             'submits': []
         }
 
-        if next_frame % 100 == 0:
+        if self.verbose and (next_frame % 100 == 0):
             print(f'Starting frame {next_frame} ...')
 
     def handle_submit(self, msg: Any) -> None:


### PR DESCRIPTION
This change allows the installer to run a copy of the network server to 
collect timeline metadata trace, rather than needing the user to run 
a separate service manually.