### PR TITLE
Add clang-format definition, and CMake targets for running the formatter

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,165 @@
+---
+Language: Cpp
+BasedOnStyle: Mozilla
+
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: Consecutive
+AlignConsecutiveDeclarations: None
+AlignConsecutiveMacros: Consecutive
+AlignEscapedNewlines: Right
+AlignOperands: AlignAfterOperator
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: InlineOnly
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+BinPackArguments: false
+BinPackParameters: false
+BitFieldColonSpacing: Both
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterStruct: true
+  AfterUnion: true
+  AfterExternBlock: true
+  BeforeCatch: true
+  BeforeElse: true
+  BeforeLambdaBody: true
+  BeforeWhile: true
+  IndentBraces: false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Custom
+BreakBeforeConceptDeclarations: true
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeColon
+BreakInheritanceList: BeforeColon
+BreakStringLiterals: false
+ColumnLimit: 120
+CommentPragmas: '\(no-format\) $'
+CompactNamespaces: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: false
+DerivePointerAlignment: false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: Always
+FixNamespaceComments: false
+ForEachMacros:
+IfMacros:
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex:          '^"[^"]+"$'
+    Priority:       2
+    SortPriority:   2
+  - Regex:          '^<[0-9A-Za-z_/]+>$'
+    Priority:       3
+    SortPriority:   3
+  - Regex:          '^<[Ww]indows.h>$'
+    Priority:       4
+    SortPriority:   4
+  - Regex:          '^<(gtest|gmock)/[^>]+\.(h|hh|hpp)>$'
+    Priority:       7
+    SortPriority:   7
+  - Regex:          '^<[^>]+\.(h|hh|hpp)>$'
+    Priority:       8
+    SortPriority:   8
+IncludeIsMainRegex: '$'
+IncludeIsMainSourceRegex: '(_impl\.hpp)$'
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: false
+IndentExternBlock: false
+IndentGotoLabels: false
+IndentPPDirectives: AfterHash
+IndentRequiresClause: false
+IndentWidth: 4 #
+IndentWrappedFunctionNames: true
+InsertBraces: true
+InsertNewlineAtEOF: true
+InsertTrailingCommas: Wrapped
+KeepEmptyLinesAtTheStartOfBlocks: false
+KeepEmptyLinesAtEOF: true
+LambdaBodyIndentation: Signature
+#MacroBlockBegin:
+#MacroBlockEnd:
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: Inner
+NamespaceMacros:
+PackConstructorInitializers: Never
+PenaltyBreakOpenParenthesis: 0
+PPIndentWidth: 2 #
+PointerAlignment: Left
+QualifierAlignment: Custom
+QualifierOrder:
+  - inline
+  - static
+  - constexpr
+  - friend
+  - const
+  - restrict
+  - volatile
+  - type
+RawStringFormats:
+ReferenceAlignment: Pointer
+ReflowComments: true
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+ShortNamespaceLines: 1
+SortIncludes: CaseSensitive
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: true
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeParens: ControlStatementsExceptControlMacros
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles: false
+SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: c++20
+StatementAttributeLikeMacros:
+StatementMacros:
+  - UNUSED
+TabWidth: 4
+TypenameMacros:
+UseCRLF: false
+UseTab: Never
+WhitespaceSensitiveMacros:
+...

--- a/cmake/clang-tools.cmake
+++ b/cmake/clang-tools.cmake
@@ -1,0 +1,73 @@
+# Copyright (C) 2025 by Arm Limited (or its affiliates). All rights reserved.
+include_guard(GLOBAL)
+
+# ###
+# Find various optional tools
+# ###
+find_file(CLANG_FORMAT NAMES "clang-format${CMAKE_EXECUTABLE_SUFFIX}"
+    NO_CMAKE_FIND_ROOT_PATH)
+
+if(EXISTS ${CLANG_FORMAT})
+    execute_process(
+        COMMAND "${CLANG_FORMAT}" --version
+        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+        RESULT_VARIABLE _cf_res
+        OUTPUT_VARIABLE _cf_out
+        ERROR_QUIET)
+    string(REGEX REPLACE "[\n\r\t]" " " _cf_out "${_cf_out}")
+    string(STRIP "${_cf_out}" _cf_out)
+
+    if(NOT "${_cf_res}" EQUAL 0)
+        message(STATUS "Failed to execute '${CLANG_FORMAT} --version'")
+        unset(CLANG_FORMAT)
+    elseif(NOT "${_cf_out}" MATCHES ".*clang-format version ([^ ]+).*")
+        message(STATUS "Failed to understand '${CLANG_FORMAT} --version' output")
+        unset(CLANG_FORMAT)
+    else()
+        string(REGEX REPLACE ".*clang-format version ([^ ]+).*" "\\1" _cf_ver "${_cf_out}")
+        message(STATUS "Detected clang-format version '${_cf_ver}'")
+
+        if("${_cf_ver}" VERSION_LESS "18.0.0")
+            message(STATUS "The version of clang-format is too old")
+            unset(CLANG_FORMAT)
+        endif()
+    endif()
+
+    unset(_cf_res)
+    unset(_cf_out)
+    unset(_cf_ver)
+endif()
+
+# ###
+# Add a custom targets for running clang-format
+# ###
+if(EXISTS ${CLANG_FORMAT})
+    add_custom_target(clang-format
+        COMMENT "Run clang-format on all targets")
+endif()
+
+# used to get the root project directory
+file(REAL_PATH "${CMAKE_CURRENT_LIST_DIR}/.." _cf_root)
+
+function(add_clang_tools)
+    if(EXISTS ${CLANG_FORMAT})
+        # Determine the name to give the custom target; base it on the folder path relative to the repo root
+        file(RELATIVE_PATH _cf_relpath "${_cf_root}" "${CMAKE_CURRENT_SOURCE_DIR}")
+        string(REGEX REPLACE "[^0-9A-Za-z_\-]" "-" _cf_name "${_cf_relpath}")
+
+        # find the sources
+        file(
+            GLOB_RECURSE _cf_srcs
+            LIST_DIRECTORIES false
+            RELATIVE "${CMAKE_CURRENT_SOURCE_DIR}"
+            CONFIGURE_DEPENDS "*.cpp" "*.hpp")
+
+        # add the task
+        add_custom_target(clang-format-${_cf_name}
+            COMMAND ${CLANG_FORMAT} -i ${_cf_srcs}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            SOURCES ${_cf_srcs}
+            COMMENT "Run clang-format on the sources in ${CMAKE_CURRENT_SOURCE_DIR} for ${_cf_name}")
+        add_dependencies(clang-format clang-format-${_cf_name})
+    endif()
+endfunction()

--- a/generator/generate_vulkan_common.py
+++ b/generator/generate_vulkan_common.py
@@ -502,6 +502,9 @@ def generate_instance_decls(
     file.write('#pragma once\n')
     file.write('\n')
 
+    file.write('// clang-format off\n')
+    file.write('\n')
+
     file.write('#include <vulkan/vulkan.h>\n')
     file.write('\n')
 
@@ -557,6 +560,8 @@ def generate_instance_decls(
 
         file.write('\n'.join(lines))
         file.write('\n')
+
+    file.write('// clang-format on\n')
 
 
 def generate_instance_defs(
@@ -695,6 +700,9 @@ def generate_device_decls(
     file.write('#pragma once\n')
     file.write('\n')
 
+    file.write('// clang-format off\n')
+    file.write('\n')
+
     file.write('#include <vulkan/vulkan.h>\n')
     file.write('\n')
 
@@ -749,6 +757,8 @@ def generate_device_decls(
 
         file.write('\n'.join(lines))
         file.write('\n')
+
+    file.write('// clang-format on\n')
 
 
 def generate_device_defs(

--- a/generator/vk_codegen/device_defs.txt
+++ b/generator/vk_codegen/device_defs.txt
@@ -1,3 +1,5 @@
+// clang-format off
+
 #include <mutex>
 
 // Include from per-layer code
@@ -10,3 +12,4 @@
 extern std::mutex g_vulkanLock;
 
 {FUNCTION_DEFS}
+// clang-format on

--- a/generator/vk_codegen/device_dispatch_table.txt
+++ b/generator/vk_codegen/device_dispatch_table.txt
@@ -1,5 +1,7 @@
 #pragma once
 
+// clang-format off
+
 #include <vulkan/vulkan.h>
 
 #include "framework/device_functions.hpp"
@@ -64,3 +66,5 @@ static inline void initDriverDeviceDispatchTable(
 }
 
 #undef ENTRY
+
+// clang-format on

--- a/generator/vk_codegen/instance_defs.txt
+++ b/generator/vk_codegen/instance_defs.txt
@@ -1,3 +1,5 @@
+// clang-format off
+
 #include <mutex>
 
 // Include from per-layer code
@@ -12,3 +14,4 @@
 extern std::mutex g_vulkanLock;
 
 {FUNCTION_DEFS}
+// clang-format on

--- a/generator/vk_codegen/instance_dispatch_table.txt
+++ b/generator/vk_codegen/instance_dispatch_table.txt
@@ -1,5 +1,7 @@
 #pragma once
 
+// clang-format off
+
 #include <vulkan/vulkan.h>
 
 #include "framework/device_functions.hpp"
@@ -67,3 +69,5 @@ static inline void initDriverInstanceDispatchTable(
 }
 
 #undef ENTRY
+
+// clang-format on

--- a/generator/vk_codegen/root_CMakeLists.txt
+++ b/generator/vk_codegen/root_CMakeLists.txt
@@ -33,6 +33,7 @@ set(LGL_CONFIG_TRACE 0)
 set(LGL_CONFIG_LOG 1)
 
 include(../source_common/compiler_helper.cmake)
+include(../cmake/clang-tools.cmake)
 
 # Build steps
 add_subdirectory(source)

--- a/generator/vk_codegen/source_CMakeLists.txt
+++ b/generator/vk_codegen/source_CMakeLists.txt
@@ -70,3 +70,5 @@ if (CMAKE_BUILD_TYPE STREQUAL "Release")
         ARGS --strip-all -o ${VK_LAYER_STRIP} $<TARGET_FILE:${VK_LAYER}>
         COMMENT "Stripped lib${VK_LAYER}.so to ${VK_LAYER_STRIP}")
 endif()
+
+add_clang_tools()

--- a/layer_example/CMakeLists.txt
+++ b/layer_example/CMakeLists.txt
@@ -33,6 +33,7 @@ set(LGL_CONFIG_TRACE 0)
 set(LGL_CONFIG_LOG 1)
 
 include(../source_common/compiler_helper.cmake)
+include(../cmake/clang-tools.cmake)
 
 # Build steps
 add_subdirectory(source)

--- a/layer_example/source/CMakeLists.txt
+++ b/layer_example/source/CMakeLists.txt
@@ -71,3 +71,5 @@ if (CMAKE_BUILD_TYPE STREQUAL "Release")
         ARGS --strip-all -o ${VK_LAYER_STRIP} $<TARGET_FILE:${VK_LAYER}>
         COMMENT "Stripped lib${VK_LAYER}.so to ${VK_LAYER_STRIP}")
 endif()
+
+add_clang_tools()

--- a/layer_example/source/device.cpp
+++ b/layer_example/source/device.cpp
@@ -23,16 +23,17 @@
  * ----------------------------------------------------------------------------
  */
 
-#include <array>
-#include <iostream>
-#include <fstream>
-#include <sys/stat.h>
-#include <vector>
+#include "device.hpp"
 
 #include "framework/utils.hpp"
-
-#include "device.hpp"
 #include "instance.hpp"
+
+#include <array>
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+#include <sys/stat.h>
 
 /**
  * @brief The dispatch lookup for all of the created Vulkan instances.
@@ -40,62 +41,54 @@
 static std::unordered_map<void*, std::unique_ptr<Device>> g_devices;
 
 /* See header for documentation. */
-const std::vector<std::string> Device::extraExtensions { };
+const std::vector<std::string> Device::extraExtensions {};
 
 /* See header for documentation. */
-void Device::store(
-    VkDevice handle,
-    std::unique_ptr<Device> device
-) {
+void Device::store(VkDevice handle, std::unique_ptr<Device> device)
+{
     void* key = getDispatchKey(handle);
-    g_devices.insert({ key, std::move(device) });
+    g_devices.insert({key, std::move(device)});
 }
 
 /* See header for documentation. */
-Device* Device::retrieve(
-    VkDevice handle
-) {
+Device* Device::retrieve(VkDevice handle)
+{
     void* key = getDispatchKey(handle);
     assert(isInMap(key, g_devices));
     return g_devices.at(key).get();
 }
 
 /* See header for documentation. */
-Device* Device::retrieve(
-    VkQueue handle
-) {
+Device* Device::retrieve(VkQueue handle)
+{
     void* key = getDispatchKey(handle);
     assert(isInMap(key, g_devices));
     return g_devices.at(key).get();
 }
 
 /* See header for documentation. */
-Device* Device::retrieve(
-    VkCommandBuffer handle
-) {
+Device* Device::retrieve(VkCommandBuffer handle)
+{
     void* key = getDispatchKey(handle);
     assert(isInMap(key, g_devices));
     return g_devices.at(key).get();
 }
 
 /* See header for documentation. */
-void Device::destroy(
-    Device* device
-) {
+void Device::destroy(Device* device)
+{
     g_devices.erase(getDispatchKey(device));
 }
 
 /* See header for documentation. */
-Device::Device(
-    Instance* _instance,
-    VkPhysicalDevice _physicalDevice,
-    VkDevice _device,
-    PFN_vkGetDeviceProcAddr nlayerGetProcAddress,
-    const VkDeviceCreateInfo& createInfo
-):
-    instance(_instance),
-    physicalDevice(_physicalDevice),
-    device(_device)
+Device::Device(Instance* _instance,
+               VkPhysicalDevice _physicalDevice,
+               VkDevice _device,
+               PFN_vkGetDeviceProcAddr nlayerGetProcAddress,
+               const VkDeviceCreateInfo& createInfo)
+    : instance(_instance),
+      physicalDevice(_physicalDevice),
+      device(_device)
 {
     UNUSED(createInfo);
 

--- a/layer_example/source/device.hpp
+++ b/layer_example/source/device.hpp
@@ -52,11 +52,10 @@
 
 #pragma once
 
-#include <vulkan/vk_layer.h>
-
 #include "framework/device_dispatch_table.hpp"
-
 #include "instance.hpp"
+
+#include <vulkan/vk_layer.h>
 
 /**
  * @brief This class implements the layer state tracker for a single device.
@@ -70,9 +69,7 @@ public:
      * @param handle   The dispatchable device handle to use as an indirect key.
      * @param device   The @c Device object to store.
      */
-    static void store(
-        VkDevice handle,
-        std::unique_ptr<Device> device);
+    static void store(VkDevice handle, std::unique_ptr<Device> device);
 
     /**
      * @brief Fetch a device from the global store of dispatchable devices.
@@ -81,8 +78,7 @@ public:
      *
      * @return The layer device context.
      */
-    static Device* retrieve(
-        VkDevice handle);
+    static Device* retrieve(VkDevice handle);
 
     /**
      * @brief Fetch a device from the global store of dispatchable devices.
@@ -91,8 +87,7 @@ public:
      *
      * @return The layer device context.
      */
-    static Device* retrieve(
-        VkQueue handle);
+    static Device* retrieve(VkQueue handle);
 
     /**
      * @brief Fetch a device from the global store of dispatchable devices.
@@ -101,16 +96,14 @@ public:
      *
      * @return The layer device context.
      */
-    static Device* retrieve(
-        VkCommandBuffer handle);
+    static Device* retrieve(VkCommandBuffer handle);
 
     /**
      * @brief Drop a device from the global store of dispatchable devices.
      *
      * @param device   The device to drop.
      */
-    static void destroy(
-        Device* device);
+    static void destroy(Device* device);
 
     /**
      * @brief Create a new layer device object.
@@ -123,12 +116,11 @@ public:
      * @param nlayerGetProcAddress   The vkGetProcAddress function in the driver/next layer down.
      * @param createInfo             The create info used to create the device.
      */
-    Device(
-        Instance* instance,
-        VkPhysicalDevice physicalDevice,
-        VkDevice device,
-        PFN_vkGetDeviceProcAddr nlayerGetProcAddress,
-        const VkDeviceCreateInfo& createInfo);
+    Device(Instance* instance,
+           VkPhysicalDevice physicalDevice,
+           VkDevice device,
+           PFN_vkGetDeviceProcAddr nlayerGetProcAddress,
+           const VkDeviceCreateInfo& createInfo);
 
     /**
      * @brief Destroy this layer device object.

--- a/layer_example/source/instance.cpp
+++ b/layer_example/source/instance.cpp
@@ -23,11 +23,11 @@
  * ----------------------------------------------------------------------------
  */
 
-#include <cassert>
+#include "instance.hpp"
 
 #include "framework/utils.hpp"
 
-#include "instance.hpp"
+#include <cassert>
 
 /**
  * @brief The dispatch lookup for all of the created Vulkan instances.
@@ -35,54 +35,44 @@
 static std::unordered_map<void*, std::unique_ptr<Instance>> g_instances;
 
 /* See header for documentation. */
-const APIVersion Instance::minAPIVersion { 1, 1 };
+const APIVersion Instance::minAPIVersion {1, 1};
 
 /* See header for documentation. */
-const std::vector<std::string> Instance::extraExtensions {
-    VK_EXT_DEBUG_UTILS_EXTENSION_NAME
-};
+const std::vector<std::string> Instance::extraExtensions {VK_EXT_DEBUG_UTILS_EXTENSION_NAME};
 
 /* See header for documentation. */
-void Instance::store(
-    VkInstance handle,
-    std::unique_ptr<Instance>& instance
-) {
+void Instance::store(VkInstance handle, std::unique_ptr<Instance>& instance)
+{
     void* key = getDispatchKey(handle);
-    g_instances.insert({ key, std::move(instance) });
+    g_instances.insert({key, std::move(instance)});
 }
 
 /* See header for documentation. */
-Instance* Instance::retrieve(
-    VkInstance handle
-) {
+Instance* Instance::retrieve(VkInstance handle)
+{
     void* key = getDispatchKey(handle);
     assert(isInMap(key, g_instances));
     return g_instances.at(key).get();
 }
 
 /* See header for documentation. */
-Instance* Instance::retrieve(
-    VkPhysicalDevice handle
-) {
+Instance* Instance::retrieve(VkPhysicalDevice handle)
+{
     void* key = getDispatchKey(handle);
     assert(isInMap(key, g_instances));
     return g_instances.at(key).get();
 }
 
 /* See header for documentation. */
-void Instance::destroy(
-    Instance* instance
-) {
+void Instance::destroy(Instance* instance)
+{
     g_instances.erase(getDispatchKey(instance->instance));
 }
 
 /* See header for documentation. */
-Instance::Instance(
-    VkInstance _instance,
-    PFN_vkGetInstanceProcAddr _nlayerGetProcAddress
-) :
-    instance(_instance),
-    nlayerGetProcAddress(_nlayerGetProcAddress)
+Instance::Instance(VkInstance _instance, PFN_vkGetInstanceProcAddr _nlayerGetProcAddress)
+    : instance(_instance),
+      nlayerGetProcAddress(_nlayerGetProcAddress)
 {
     initDriverInstanceDispatchTable(instance, nlayerGetProcAddress, driver);
 }

--- a/layer_example/source/instance.hpp
+++ b/layer_example/source/instance.hpp
@@ -54,13 +54,13 @@
 
 #pragma once
 
+#include "framework/instance_dispatch_table.hpp"
+
 #include <memory>
 #include <unordered_map>
 
 #include <vulkan/vk_layer.h>
 #include <vulkan/vulkan.h>
-
-#include "framework/instance_dispatch_table.hpp"
 
 /**
  * @brief This class implements the layer state tracker for a single instance.
@@ -74,9 +74,7 @@ public:
      * @param handle     The dispatchable instance handle to use as an indirect key.
      * @param instance   The @c Instance object to store.
      */
-    static void store(
-        VkInstance handle,
-        std::unique_ptr<Instance>& instance);
+    static void store(VkInstance handle, std::unique_ptr<Instance>& instance);
 
     /**
      * @brief Fetch an instance from the global store of dispatchable instances.
@@ -85,8 +83,7 @@ public:
      *
      * @return The layer instance context.
      */
-    static Instance* retrieve(
-        VkInstance handle);
+    static Instance* retrieve(VkInstance handle);
 
     /**
      * @brief Fetch an instance from the global store of dispatchable instances.
@@ -95,16 +92,14 @@ public:
      *
      * @return The layer instance context.
      */
-    static Instance* retrieve(
-        VkPhysicalDevice handle);
+    static Instance* retrieve(VkPhysicalDevice handle);
 
     /**
      * @brief Drop an instance from the global store of dispatchable instances.
      *
      * @param instance   The instance to drop.
      */
-    static void destroy(
-        Instance* instance);
+    static void destroy(Instance* instance);
 
     /**
      * @brief Create a new layer instance object.
@@ -112,9 +107,7 @@ public:
      * @param instance               The instance handle this instance is created with.
      * @param nlayerGetProcAddress   The vkGetProcAddress function in the driver/next layer down.
      */
-    Instance(
-        VkInstance instance,
-        PFN_vkGetInstanceProcAddr nlayerGetProcAddress);
+    Instance(VkInstance instance, PFN_vkGetInstanceProcAddr nlayerGetProcAddress);
 
 public:
     /**

--- a/layer_example/source/layer_device_functions.cpp
+++ b/layer_example/source/layer_device_functions.cpp
@@ -23,28 +23,27 @@
  * ----------------------------------------------------------------------------
  */
 
+#include "device.hpp"
+#include "framework/device_dispatch_table.hpp"
+
 #include <memory>
 #include <mutex>
 #include <thread>
 
-#include "device.hpp"
-#include "layer_device_functions.hpp"
-
 extern std::mutex g_vulkanLock;
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderPassBeginInfo* pRenderPassBegin,
-    VkSubpassContents contents
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass<user_tag>(VkCommandBuffer commandBuffer,
+                                                                const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                                VkSubpassContents contents)
+{
 #if CONFIG_TRACE == 1
     LAYER_LOG("API Trace: Layer: %s ", __func__);
 #endif
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver
@@ -53,18 +52,17 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderPassBeginInfo* pRenderPassBegin,
-    const VkSubpassBeginInfo* pSubpassBeginInfo
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2<user_tag>(VkCommandBuffer commandBuffer,
+                                                                 const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                                 const VkSubpassBeginInfo* pSubpassBeginInfo)
+{
 #if CONFIG_TRACE == 1
     LAYER_LOG("API Trace: Layer: %s ", __func__);
 #endif
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver
@@ -73,18 +71,17 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2KHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderPassBeginInfo* pRenderPassBegin,
-    const VkSubpassBeginInfo* pSubpassBeginInfo
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2KHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                    const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                                    const VkSubpassBeginInfo* pSubpassBeginInfo)
+{
 #if CONFIG_TRACE == 1
     LAYER_LOG("API Trace: Layer: %s ", __func__);
 #endif
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver
@@ -93,17 +90,16 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2KHR<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRendering<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderingInfo* pRenderingInfo
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRendering<user_tag>(VkCommandBuffer commandBuffer,
+                                                               const VkRenderingInfo* pRenderingInfo)
+{
 #if CONFIG_TRACE == 1
     LAYER_LOG("API Trace: Layer: %s ", __func__);
 #endif
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver
@@ -112,17 +108,16 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRendering<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderingKHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderingInfo* pRenderingInfo
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderingKHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                  const VkRenderingInfo* pRenderingInfo)
+{
 #if CONFIG_TRACE == 1
     LAYER_LOG("API Trace: Layer: %s ", __func__);
 #endif
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver

--- a/layer_example/source/layer_device_functions.hpp
+++ b/layer_example/source/layer_device_functions.hpp
@@ -23,37 +23,34 @@
  * ----------------------------------------------------------------------------
  */
 
-#include "framework/utils.hpp"
+#pragma once
+
+#include <vulkan/vulkan.h>
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderPassBeginInfo* pRenderPassBegin,
-    VkSubpassContents contents);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass<user_tag>(VkCommandBuffer commandBuffer,
+                                                                const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                                VkSubpassContents contents);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderPassBeginInfo* pRenderPassBegin,
-    const VkSubpassBeginInfo* pSubpassBeginInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2<user_tag>(VkCommandBuffer commandBuffer,
+                                                                 const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                                 const VkSubpassBeginInfo* pSubpassBeginInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2KHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderPassBeginInfo* pRenderPassBegin,
-    const VkSubpassBeginInfo* pSubpassBeginInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2KHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                    const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                                    const VkSubpassBeginInfo* pSubpassBeginInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRendering<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderingInfo* pRenderingInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRendering<user_tag>(VkCommandBuffer commandBuffer,
+                                                               const VkRenderingInfo* pRenderingInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderingKHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderingInfo* pRenderingInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderingKHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                  const VkRenderingInfo* pRenderingInfo);

--- a/layer_gpu_support/CMakeLists.txt
+++ b/layer_gpu_support/CMakeLists.txt
@@ -33,6 +33,7 @@ set(LGL_CONFIG_TRACE 0)
 set(LGL_CONFIG_LOG 1)
 
 include(../source_common/compiler_helper.cmake)
+include(../cmake/clang-tools.cmake)
 
 # Build steps
 add_subdirectory(source)

--- a/layer_gpu_support/source/CMakeLists.txt
+++ b/layer_gpu_support/source/CMakeLists.txt
@@ -79,3 +79,5 @@ if (CMAKE_BUILD_TYPE STREQUAL "Release")
         ARGS --strip-all -o ${VK_LAYER_STRIP} $<TARGET_FILE:${VK_LAYER}>
         COMMENT "Stripped lib${VK_LAYER}.so to ${VK_LAYER_STRIP}")
 endif()
+
+add_clang_tools()

--- a/layer_gpu_support/source/device.cpp
+++ b/layer_gpu_support/source/device.cpp
@@ -23,9 +23,9 @@
  * ----------------------------------------------------------------------------
  */
 
-#include "framework/utils.hpp"
-
 #include "device.hpp"
+
+#include "framework/utils.hpp"
 #include "instance.hpp"
 
 /**
@@ -36,63 +36,55 @@ static std::unordered_map<void*, std::unique_ptr<Device>> g_devices;
 /* See header for documentation. */
 const std::vector<std::string> Device::extraExtensions {
     VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME,
-    VK_EXT_IMAGE_COMPRESSION_CONTROL_EXTENSION_NAME
+    VK_EXT_IMAGE_COMPRESSION_CONTROL_EXTENSION_NAME,
 };
 
 /* See header for documentation. */
-void Device::store(
-    VkDevice handle,
-    std::unique_ptr<Device> device
-) {
+void Device::store(VkDevice handle, std::unique_ptr<Device> device)
+{
     void* key = getDispatchKey(handle);
-    g_devices.insert({ key, std::move(device) });
+    g_devices.insert({key, std::move(device)});
 }
 
 /* See header for documentation. */
-Device* Device::retrieve(
-    VkDevice handle
-) {
+Device* Device::retrieve(VkDevice handle)
+{
     void* key = getDispatchKey(handle);
     assert(isInMap(key, g_devices));
     return g_devices.at(key).get();
 }
 
 /* See header for documentation. */
-Device* Device::retrieve(
-    VkQueue handle
-) {
+Device* Device::retrieve(VkQueue handle)
+{
     void* key = getDispatchKey(handle);
     assert(isInMap(key, g_devices));
     return g_devices.at(key).get();
 }
 
 /* See header for documentation. */
-Device* Device::retrieve(
-    VkCommandBuffer handle
-) {
+Device* Device::retrieve(VkCommandBuffer handle)
+{
     void* key = getDispatchKey(handle);
     assert(isInMap(key, g_devices));
     return g_devices.at(key).get();
 }
 
 /* See header for documentation. */
-void Device::destroy(
-    Device* device
-) {
+void Device::destroy(Device* device)
+{
     g_devices.erase(getDispatchKey(device));
 }
 
 /* See header for documentation. */
-Device::Device(
-    Instance* _instance,
-    VkPhysicalDevice _physicalDevice,
-    VkDevice _device,
-    PFN_vkGetDeviceProcAddr nlayerGetProcAddress,
-    const VkDeviceCreateInfo& createInfo
-):
-    instance(_instance),
-    physicalDevice(_physicalDevice),
-    device(_device)
+Device::Device(Instance* _instance,
+               VkPhysicalDevice _physicalDevice,
+               VkDevice _device,
+               PFN_vkGetDeviceProcAddr nlayerGetProcAddress,
+               const VkDeviceCreateInfo& createInfo)
+    : instance(_instance),
+      physicalDevice(_physicalDevice),
+      device(_device)
 {
     UNUSED(createInfo);
 
@@ -102,17 +94,16 @@ Device::Device(
         .sType = VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO,
         .pNext = nullptr,
         .semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE,
-        .initialValue = queueSerializationTimelineSemCount
+        .initialValue = queueSerializationTimelineSemCount,
     };
 
     VkSemaphoreCreateInfo semCreateInfo {
         .sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO,
         .pNext = &timelineCreateInfo,
-        .flags = 0
+        .flags = 0,
     };
 
-    auto result = driver.vkCreateSemaphore(
-        device, &semCreateInfo, nullptr, &queueSerializationTimelineSem);
+    auto result = driver.vkCreateSemaphore(device, &semCreateInfo, nullptr, &queueSerializationTimelineSem);
     if (result != VK_SUCCESS)
     {
         LAYER_ERR("Failed vkCreateSemaphore() for queue serialization");

--- a/layer_gpu_support/source/device.hpp
+++ b/layer_gpu_support/source/device.hpp
@@ -52,11 +52,10 @@
 
 #pragma once
 
-#include <vulkan/vk_layer.h>
-
 #include "framework/device_dispatch_table.hpp"
-
 #include "instance.hpp"
+
+#include <vulkan/vk_layer.h>
 
 /**
  * @brief This class implements the layer state tracker for a single device.
@@ -70,9 +69,7 @@ public:
      * @param handle   The dispatchable device handle to use as an indirect key.
      * @param device   The @c Device object to store.
      */
-    static void store(
-        VkDevice handle,
-        std::unique_ptr<Device> device);
+    static void store(VkDevice handle, std::unique_ptr<Device> device);
 
     /**
      * @brief Fetch a device from the global store of dispatchable devices.
@@ -81,8 +78,7 @@ public:
      *
      * @return The layer device context.
      */
-    static Device* retrieve(
-        VkDevice handle);
+    static Device* retrieve(VkDevice handle);
 
     /**
      * @brief Fetch a device from the global store of dispatchable devices.
@@ -91,8 +87,7 @@ public:
      *
      * @return The layer device context.
      */
-    static Device* retrieve(
-        VkQueue handle);
+    static Device* retrieve(VkQueue handle);
 
     /**
      * @brief Fetch a device from the global store of dispatchable devices.
@@ -101,16 +96,14 @@ public:
      *
      * @return The layer device context.
      */
-    static Device* retrieve(
-        VkCommandBuffer handle);
+    static Device* retrieve(VkCommandBuffer handle);
 
     /**
      * @brief Drop a device from the global store of dispatchable devices.
      *
      * @param device   The device to drop.
      */
-    static void destroy(
-        Device* device);
+    static void destroy(Device* device);
 
     /**
      * @brief Create a new layer device object.
@@ -123,12 +116,11 @@ public:
      * @param nlayerGetProcAddress   The vkGetProcAddress function in the driver/next layer down.
      * @param createInfo             The create info used to create the device.
      */
-    Device(
-        Instance* instance,
-        VkPhysicalDevice physicalDevice,
-        VkDevice device,
-        PFN_vkGetDeviceProcAddr nlayerGetProcAddress,
-        const VkDeviceCreateInfo& createInfo);
+    Device(Instance* instance,
+           VkPhysicalDevice physicalDevice,
+           VkDevice device,
+           PFN_vkGetDeviceProcAddr nlayerGetProcAddress,
+           const VkDeviceCreateInfo& createInfo);
 
     /**
      * @brief Destroy this layer device object.
@@ -164,10 +156,10 @@ public:
     /**
      * @brief The timeline sem use for queue serialization.
      */
-    VkSemaphore queueSerializationTimelineSem { nullptr };
+    VkSemaphore queueSerializationTimelineSem {nullptr};
 
     /**
      * @brief The current timeline sem target value the next use waits for.
      */
-    uint64_t queueSerializationTimelineSemCount { 0 };
+    uint64_t queueSerializationTimelineSemCount {0};
 };

--- a/layer_gpu_support/source/instance.cpp
+++ b/layer_gpu_support/source/instance.cpp
@@ -23,11 +23,11 @@
  * ----------------------------------------------------------------------------
  */
 
-#include <cassert>
+#include "instance.hpp"
 
 #include "framework/utils.hpp"
 
-#include "instance.hpp"
+#include <cassert>
 
 /**
  * @brief The dispatch lookup for all of the created Vulkan instances.
@@ -35,54 +35,46 @@
 static std::unordered_map<void*, std::unique_ptr<Instance>> g_instances;
 
 /* See header for documentation. */
-const APIVersion Instance::minAPIVersion { 1, 1 };
+const APIVersion Instance::minAPIVersion {1, 1};
 
 /* See header for documentation. */
 const std::vector<std::string> Instance::extraExtensions {
-    VK_EXT_DEBUG_UTILS_EXTENSION_NAME
+    VK_EXT_DEBUG_UTILS_EXTENSION_NAME,
 };
 
 /* See header for documentation. */
-void Instance::store(
-    VkInstance handle,
-    std::unique_ptr<Instance>& instance
-) {
+void Instance::store(VkInstance handle, std::unique_ptr<Instance>& instance)
+{
     void* key = getDispatchKey(handle);
-    g_instances.insert({ key, std::move(instance) });
+    g_instances.insert({key, std::move(instance)});
 }
 
 /* See header for documentation. */
-Instance* Instance::retrieve(
-    VkInstance handle
-) {
+Instance* Instance::retrieve(VkInstance handle)
+{
     void* key = getDispatchKey(handle);
     assert(isInMap(key, g_instances));
     return g_instances.at(key).get();
 }
 
 /* See header for documentation. */
-Instance* Instance::retrieve(
-    VkPhysicalDevice handle
-) {
+Instance* Instance::retrieve(VkPhysicalDevice handle)
+{
     void* key = getDispatchKey(handle);
     assert(isInMap(key, g_instances));
     return g_instances.at(key).get();
 }
 
 /* See header for documentation. */
-void Instance::destroy(
-    Instance* instance
-) {
+void Instance::destroy(Instance* instance)
+{
     g_instances.erase(getDispatchKey(instance->instance));
 }
 
 /* See header for documentation. */
-Instance::Instance(
-    VkInstance _instance,
-    PFN_vkGetInstanceProcAddr _nlayerGetProcAddress
-) :
-    instance(_instance),
-    nlayerGetProcAddress(_nlayerGetProcAddress)
+Instance::Instance(VkInstance _instance, PFN_vkGetInstanceProcAddr _nlayerGetProcAddress)
+    : instance(_instance),
+      nlayerGetProcAddress(_nlayerGetProcAddress)
 {
     initDriverInstanceDispatchTable(instance, nlayerGetProcAddress, driver);
 }

--- a/layer_gpu_support/source/instance.hpp
+++ b/layer_gpu_support/source/instance.hpp
@@ -54,14 +54,13 @@
 
 #pragma once
 
+#include "framework/instance_dispatch_table.hpp"
+#include "layer_config.hpp"
+
 #include <memory>
 
 #include <vulkan/vk_layer.h>
 #include <vulkan/vulkan.h>
-
-#include "framework/instance_dispatch_table.hpp"
-
-#include "layer_config.hpp"
 
 /**
  * @brief This class implements the layer state tracker for a single instance.
@@ -75,9 +74,7 @@ public:
      * @param handle     The dispatchable instance handle to use as an indirect key.
      * @param instance   The @c Instance object to store.
      */
-    static void store(
-        VkInstance handle,
-        std::unique_ptr<Instance>& instance);
+    static void store(VkInstance handle, std::unique_ptr<Instance>& instance);
 
     /**
      * @brief Fetch an instance from the global store of dispatchable instances.
@@ -86,8 +83,7 @@ public:
      *
      * @return The layer instance context.
      */
-    static Instance* retrieve(
-        VkInstance handle);
+    static Instance* retrieve(VkInstance handle);
 
     /**
      * @brief Fetch an instance from the global store of dispatchable instances.
@@ -96,16 +92,14 @@ public:
      *
      * @return The layer instance context.
      */
-    static Instance* retrieve(
-        VkPhysicalDevice handle);
+    static Instance* retrieve(VkPhysicalDevice handle);
 
     /**
      * @brief Drop an instance from the global store of dispatchable instances.
      *
      * @param instance   The instance to drop.
      */
-    static void destroy(
-        Instance* instance);
+    static void destroy(Instance* instance);
 
     /**
      * @brief Create a new layer instance object.
@@ -113,9 +107,7 @@ public:
      * @param instance               The instance handle this instance is created with.
      * @param nlayerGetProcAddress   The vkGetProcAddress function in the driver/next layer down.
      */
-    Instance(
-        VkInstance instance,
-        PFN_vkGetInstanceProcAddr nlayerGetProcAddress);
+    Instance(VkInstance instance, PFN_vkGetInstanceProcAddr nlayerGetProcAddress);
 
 public:
     /**

--- a/layer_gpu_support/source/layer_config.cpp
+++ b/layer_gpu_support/source/layer_config.cpp
@@ -28,20 +28,18 @@
  * Defines the a config file to parameterize the layer.
  */
 
+#include "layer_config.hpp"
+
+#include "framework/utils.hpp"
+#include "version.hpp"
+
 #include <fstream>
 
 #include <vulkan/vulkan.h>
 
-#include "framework/utils.hpp"
-
-#include "layer_config.hpp"
-#include "version.hpp"
-
-
 /* See header for documentation. */
-void LayerConfig::parse_serialization_options(
-    const json& config
-) {
+void LayerConfig::parse_serialization_options(const json& config)
+{
     // Decode serialization state
     json serialize = config.at("serialize");
 
@@ -90,9 +88,8 @@ void LayerConfig::parse_serialization_options(
 }
 
 /* See header for documentation. */
-void LayerConfig::parse_shader_options(
-    const json& config
-) {
+void LayerConfig::parse_shader_options(const json& config)
+{
     // Decode serialization state
     json shader = config.at("shader");
 
@@ -113,9 +110,8 @@ void LayerConfig::parse_shader_options(
 }
 
 /* See header for documentation. */
-void LayerConfig::parse_framebuffer_options(
-    const json& config
-) {
+void LayerConfig::parse_framebuffer_options(const json& config)
+{
     // Decode serialization state
     json framebuffer = config.at("framebuffer");
 
@@ -135,7 +131,7 @@ void LayerConfig::parse_framebuffer_options(
     }
 
     // Convert fixed_rate_compression into a bit mask
-    uint32_t fixed_rate_mask { 0 };
+    uint32_t fixed_rate_mask {0};
     if (force_fixed_rate_compression > 0)
     {
         if (force_fixed_rate_compression <= 1)
@@ -202,7 +198,6 @@ LayerConfig::LayerConfig()
     std::string file_name(LGL_LAYER_CONFIG);
 #endif
 
-
     LAYER_LOG("Trying to read config: %s", file_name.c_str());
 
     std::ifstream stream(file_name);
@@ -218,7 +213,7 @@ LayerConfig::LayerConfig()
     {
         data = json::parse(stream);
     }
-    catch(const json::parse_error& e)
+    catch (const json::parse_error& e)
     {
         LAYER_ERR("Failed to load layer config, using defaults");
         LAYER_ERR("Error: %s", e.what());
@@ -229,7 +224,7 @@ LayerConfig::LayerConfig()
     {
         parse_serialization_options(data);
     }
-    catch(const json::out_of_range& e)
+    catch (const json::out_of_range& e)
     {
         LAYER_ERR("Failed to read serialization config, using defaults");
         LAYER_ERR("Error: %s", e.what());
@@ -239,7 +234,7 @@ LayerConfig::LayerConfig()
     {
         parse_shader_options(data);
     }
-    catch(const json::out_of_range& e)
+    catch (const json::out_of_range& e)
     {
         LAYER_ERR("Failed to read shader config, using defaults");
         LAYER_ERR("Error: %s", e.what());
@@ -249,7 +244,7 @@ LayerConfig::LayerConfig()
     {
         parse_framebuffer_options(data);
     }
-    catch(const json::out_of_range& e)
+    catch (const json::out_of_range& e)
     {
         LAYER_ERR("Failed to read framebuffer config, using defaults");
         LAYER_ERR("Error: %s", e.what());

--- a/layer_gpu_support/source/layer_config.hpp
+++ b/layer_gpu_support/source/layer_config.hpp
@@ -44,7 +44,7 @@ using json = nlohmann::json;
 class LayerConfig
 {
 public:
-     /**
+    /**
      * @brief Create a new layer config.
      */
     LayerConfig();
@@ -138,7 +138,6 @@ public:
      */
     uint32_t framebuffer_force_fixed_rate_compression() const;
 
-
 private:
     /**
      * @brief Parse the configuration options for the serializer.
@@ -171,62 +170,62 @@ private:
     /**
      * @brief True if we force serialize across queues.
      */
-    bool conf_serialize_queues { false };
+    bool conf_serialize_queues {false};
 
     /**
      * @brief True if we force serialize before compute dispatches.
      */
-    bool conf_serialize_dispatch_pre { false };
+    bool conf_serialize_dispatch_pre {false};
 
     /**
      * @brief True if we force serialize after compute dispatches.
      */
-    bool conf_serialize_dispatch_post { false };
+    bool conf_serialize_dispatch_post {false};
 
     /**
      * @brief True if we force serialize before render pass workloads.
      */
-    bool conf_serialize_render_pass_pre { false };
+    bool conf_serialize_render_pass_pre {false};
 
     /**
      * @brief True if we force serialize after render pass workloads.
      */
-    bool conf_serialize_render_pass_post { false };
+    bool conf_serialize_render_pass_post {false};
 
     /**
      * @brief True if we force serialize before trace rays workloads.
      */
-    bool conf_serialize_trace_rays_pre { false };
+    bool conf_serialize_trace_rays_pre {false};
 
     /**
      * @brief True if we force serialize after trace rays workloads.
      */
-    bool conf_serialize_trace_rays_post { false };
+    bool conf_serialize_trace_rays_post {false};
 
     /**
      * @brief True if we force serialize before transfer workloads.
      */
-    bool conf_serialize_transfer_pre { false };
+    bool conf_serialize_transfer_pre {false};
 
     /**
      * @brief True if we force serialize after transfer workloads.
      */
-    bool conf_serialize_transfer_post { false };
+    bool conf_serialize_transfer_post {false};
 
     /**
      * @brief True if we force disable executable binary caching.
      */
-    bool conf_shader_disable_program_cache { false };
+    bool conf_shader_disable_program_cache {false};
 
     /**
      * @brief True if we force remove use of relaxed precision decoration.
      */
-    bool conf_shader_disable_relaxed_precision { false };
+    bool conf_shader_disable_relaxed_precision {false};
 
     /**
      * @brief True if we change SPIR-V to change the program hash.
      */
-    bool conf_shader_enable_fuzz_spirv_hash { false };
+    bool conf_shader_enable_fuzz_spirv_hash {false};
 
     /**
      * @brief True if we disable all framebuffer compression.
@@ -234,14 +233,14 @@ private:
      * This has precedence over default compression and forcing fixed rate
      * compression.
      */
-    bool conf_framebuffer_disable_compression { false };
+    bool conf_framebuffer_disable_compression {false};
 
     /**
      * @brief True if we for all compression to default framebuffer compression.
      *
      * This has precedence over forcing fixed rate compression.
      */
-    bool conf_framebuffer_force_default_compression { false };
+    bool conf_framebuffer_force_default_compression {false};
 
     /**
      * @brief True if we force fixed rate compression.
@@ -254,5 +253,5 @@ private:
      *
      * If zero, then no force is set and default compression will be used.
      */
-    uint32_t conf_framebuffer_force_fixed_rate_compression { 0 };
+    uint32_t conf_framebuffer_force_fixed_rate_compression {0};
 };

--- a/layer_gpu_support/source/layer_device_functions.hpp
+++ b/layer_gpu_support/source/layer_device_functions.hpp
@@ -27,337 +27,297 @@
 
 #include <vulkan/vulkan.h>
 
-#include "framework/utils.hpp"
-
 // Functions for render passes
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderPassBeginInfo* pRenderPassBegin,
-    VkSubpassContents contents);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass<user_tag>(VkCommandBuffer commandBuffer,
+                                                                const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                                VkSubpassContents contents);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderPassBeginInfo* pRenderPassBegin,
-    const VkSubpassBeginInfo* pSubpassBeginInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2<user_tag>(VkCommandBuffer commandBuffer,
+                                                                 const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                                 const VkSubpassBeginInfo* pSubpassBeginInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2KHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderPassBeginInfo* pRenderPassBegin,
-    const VkSubpassBeginInfo* pSubpassBeginInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2KHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                    const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                                    const VkSubpassBeginInfo* pSubpassBeginInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRendering<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderingInfo* pRenderingInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRendering<user_tag>(VkCommandBuffer commandBuffer,
+                                                               const VkRenderingInfo* pRenderingInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderingKHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderingInfo* pRenderingInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderingKHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                  const VkRenderingInfo* pRenderingInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderPass<user_tag>(
-    VkCommandBuffer commandBuffer);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderPass<user_tag>(VkCommandBuffer commandBuffer);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL  layer_vkCmdEndRendering<user_tag>(
-    VkCommandBuffer commandBuffer);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRendering<user_tag>(VkCommandBuffer commandBuffer);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL  layer_vkCmdEndRenderingKHR<user_tag>(
-    VkCommandBuffer commandBuffer);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderingKHR<user_tag>(VkCommandBuffer commandBuffer);
 
 // Functions for compute dispatches
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatch<user_tag>(
-    VkCommandBuffer commandBuffer,
-    uint32_t groupCountX,
-    uint32_t groupCountY,
-    uint32_t groupCountZ);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatch<user_tag>(VkCommandBuffer commandBuffer,
+                                                         uint32_t groupCountX,
+                                                         uint32_t groupCountY,
+                                                         uint32_t groupCountZ);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatchBase<user_tag>(
-    VkCommandBuffer commandBuffer,
-    uint32_t baseGroupX,
-    uint32_t baseGroupY,
-    uint32_t baseGroupZ,
-    uint32_t groupCountX,
-    uint32_t groupCountY,
-    uint32_t groupCountZ);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatchBase<user_tag>(VkCommandBuffer commandBuffer,
+                                                             uint32_t baseGroupX,
+                                                             uint32_t baseGroupY,
+                                                             uint32_t baseGroupZ,
+                                                             uint32_t groupCountX,
+                                                             uint32_t groupCountY,
+                                                             uint32_t groupCountZ);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatchBaseKHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    uint32_t baseGroupX,
-    uint32_t baseGroupY,
-    uint32_t baseGroupZ,
-    uint32_t groupCountX,
-    uint32_t groupCountY,
-    uint32_t groupCountZ);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatchBaseKHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                uint32_t baseGroupX,
+                                                                uint32_t baseGroupY,
+                                                                uint32_t baseGroupZ,
+                                                                uint32_t groupCountX,
+                                                                uint32_t groupCountY,
+                                                                uint32_t groupCountZ);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatchIndirect<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer buffer,
-    VkDeviceSize offset);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatchIndirect<user_tag>(VkCommandBuffer commandBuffer,
+                                                                 VkBuffer buffer,
+                                                                 VkDeviceSize offset);
 
 // Commands for trace rays
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdTraceRaysIndirect2KHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkDeviceAddress indirectDeviceAddress);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdTraceRaysIndirect2KHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                      VkDeviceAddress indirectDeviceAddress);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdTraceRaysIndirectKHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
-    const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
-    const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
-    const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
-    VkDeviceAddress indirectDeviceAddress);
+template<>
+VKAPI_ATTR void VKAPI_CALL
+    layer_vkCmdTraceRaysIndirectKHR<user_tag>(VkCommandBuffer commandBuffer,
+                                              const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
+                                              const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
+                                              const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
+                                              const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
+                                              VkDeviceAddress indirectDeviceAddress);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdTraceRaysKHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
-    const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
-    const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
-    const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
-    uint32_t width,
-    uint32_t height,
-    uint32_t depth);
-
+template<>
+VKAPI_ATTR void VKAPI_CALL
+    layer_vkCmdTraceRaysKHR<user_tag>(VkCommandBuffer commandBuffer,
+                                      const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
+                                      const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
+                                      const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
+                                      const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
+                                      uint32_t width,
+                                      uint32_t height,
+                                      uint32_t depth);
 
 // Commands for transfers
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdFillBuffer<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer dstBuffer,
-    VkDeviceSize dstOffset,
-    VkDeviceSize size,
-    uint32_t data);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdFillBuffer<user_tag>(VkCommandBuffer commandBuffer,
+                                                           VkBuffer dstBuffer,
+                                                           VkDeviceSize dstOffset,
+                                                           VkDeviceSize size,
+                                                           uint32_t data);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdClearColorImage<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkImage image,
-    VkImageLayout imageLayout,
-    const VkClearColorValue* pColor,
-    uint32_t rangeCount,
-    const VkImageSubresourceRange* pRanges);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdClearColorImage<user_tag>(VkCommandBuffer commandBuffer,
+                                                                VkImage image,
+                                                                VkImageLayout imageLayout,
+                                                                const VkClearColorValue* pColor,
+                                                                uint32_t rangeCount,
+                                                                const VkImageSubresourceRange* pRanges);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdClearDepthStencilImage<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkImage image,
-    VkImageLayout imageLayout,
-    const VkClearDepthStencilValue* pDepthStencil,
-    uint32_t rangeCount,
-    const VkImageSubresourceRange* pRanges);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdClearDepthStencilImage<user_tag>(VkCommandBuffer commandBuffer,
+                                                                       VkImage image,
+                                                                       VkImageLayout imageLayout,
+                                                                       const VkClearDepthStencilValue* pDepthStencil,
+                                                                       uint32_t rangeCount,
+                                                                       const VkImageSubresourceRange* pRanges);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer srcBuffer,
-    VkBuffer dstBuffer,
-    uint32_t regionCount,
-    const VkBufferCopy* pRegions);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer<user_tag>(VkCommandBuffer commandBuffer,
+                                                           VkBuffer srcBuffer,
+                                                           VkBuffer dstBuffer,
+                                                           uint32_t regionCount,
+                                                           const VkBufferCopy* pRegions);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer2<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyBufferInfo2* pCopyBufferInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer2<user_tag>(VkCommandBuffer commandBuffer,
+                                                            const VkCopyBufferInfo2* pCopyBufferInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer2KHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyBufferInfo2* pCopyBufferInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer2KHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                               const VkCopyBufferInfo2* pCopyBufferInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBufferToImage<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer srcBuffer,
-    VkImage dstImage,
-    VkImageLayout dstImageLayout,
-    uint32_t regionCount,
-    const VkBufferImageCopy* pRegions);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBufferToImage<user_tag>(VkCommandBuffer commandBuffer,
+                                                                  VkBuffer srcBuffer,
+                                                                  VkImage dstImage,
+                                                                  VkImageLayout dstImageLayout,
+                                                                  uint32_t regionCount,
+                                                                  const VkBufferImageCopy* pRegions);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBufferToImage2<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL
+    layer_vkCmdCopyBufferToImage2<user_tag>(VkCommandBuffer commandBuffer,
+                                            const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBufferToImage2KHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL
+    layer_vkCmdCopyBufferToImage2KHR<user_tag>(VkCommandBuffer commandBuffer,
+                                               const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkImage srcImage,
-    VkImageLayout srcImageLayout,
-    VkImage dstImage,
-    VkImageLayout dstImageLayout,
-    uint32_t regionCount,
-    const VkImageCopy* pRegions);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage<user_tag>(VkCommandBuffer commandBuffer,
+                                                          VkImage srcImage,
+                                                          VkImageLayout srcImageLayout,
+                                                          VkImage dstImage,
+                                                          VkImageLayout dstImageLayout,
+                                                          uint32_t regionCount,
+                                                          const VkImageCopy* pRegions);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage2<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyImageInfo2* pCopyImageInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage2<user_tag>(VkCommandBuffer commandBuffer,
+                                                           const VkCopyImageInfo2* pCopyImageInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage2KHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyImageInfo2* pCopyImageInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage2KHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                              const VkCopyImageInfo2* pCopyImageInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImageToBuffer<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkImage srcImage,
-    VkImageLayout srcImageLayout,
-    VkBuffer dstBuffer,
-    uint32_t regionCount,
-    const VkBufferImageCopy* pRegions);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImageToBuffer<user_tag>(VkCommandBuffer commandBuffer,
+                                                                  VkImage srcImage,
+                                                                  VkImageLayout srcImageLayout,
+                                                                  VkBuffer dstBuffer,
+                                                                  uint32_t regionCount,
+                                                                  const VkBufferImageCopy* pRegions);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImageToBuffer2<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL
+    layer_vkCmdCopyImageToBuffer2<user_tag>(VkCommandBuffer commandBuffer,
+                                            const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImageToBuffer2KHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL
+    layer_vkCmdCopyImageToBuffer2KHR<user_tag>(VkCommandBuffer commandBuffer,
+                                               const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo);
 
 // Functions for queues
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit<user_tag>(
-    VkQueue queue,
-    uint32_t submitCount,
-    const VkSubmitInfo* pSubmits,
-    VkFence fence);
+VKAPI_ATTR VkResult VKAPI_CALL
+    layer_vkQueueSubmit<user_tag>(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence);
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit2<user_tag>(
-    VkQueue queue,
-    uint32_t submitCount,
-    const VkSubmitInfo2* pSubmits,
-    VkFence fence);
+VKAPI_ATTR VkResult VKAPI_CALL
+    layer_vkQueueSubmit2<user_tag>(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence);
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit2KHR<user_tag>(
-    VkQueue queue,
-    uint32_t submitCount,
-    const VkSubmitInfo2* pSubmits,
-    VkFence fence);
+VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit2KHR<user_tag>(VkQueue queue,
+                                                                 uint32_t submitCount,
+                                                                 const VkSubmitInfo2* pSubmits,
+                                                                 VkFence fence);
 
 // Functions for pipelines
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateShaderModule<user_tag>(
-    VkDevice device,
-    const VkShaderModuleCreateInfo* pCreateInfo,
-    const VkAllocationCallbacks* pAllocator,
-    VkShaderModule* pShaderModule);
+VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateShaderModule<user_tag>(VkDevice device,
+                                                                    const VkShaderModuleCreateInfo* pCreateInfo,
+                                                                    const VkAllocationCallbacks* pAllocator,
+                                                                    VkShaderModule* pShaderModule);
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateShadersEXT<user_tag>(
-    VkDevice device,
-    uint32_t createInfoCount,
-    const VkShaderCreateInfoEXT* pCreateInfos,
-    const VkAllocationCallbacks* pAllocator,
-    VkShaderEXT* pShaders);
-
+VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateShadersEXT<user_tag>(VkDevice device,
+                                                                  uint32_t createInfoCount,
+                                                                  const VkShaderCreateInfoEXT* pCreateInfos,
+                                                                  const VkAllocationCallbacks* pAllocator,
+                                                                  VkShaderEXT* pShaders);
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkGetPipelineKeyKHR<user_tag>(
-    VkDevice device,
-    const VkPipelineCreateInfoKHR* pPipelineCreateInfo,
-    VkPipelineBinaryKeyKHR* pPipelineKey);
+VKAPI_ATTR VkResult VKAPI_CALL layer_vkGetPipelineKeyKHR<user_tag>(VkDevice device,
+                                                                   const VkPipelineCreateInfoKHR* pPipelineCreateInfo,
+                                                                   VkPipelineBinaryKeyKHR* pPipelineKey);
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateComputePipelines<user_tag>(
-    VkDevice device,
-    VkPipelineCache pipelineCache,
-    uint32_t createInfoCount,
-    const VkComputePipelineCreateInfo* pCreateInfos,
-    const VkAllocationCallbacks* pAllocator,
-    VkPipeline* pPipelines);
+VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateComputePipelines<user_tag>(VkDevice device,
+                                                                        VkPipelineCache pipelineCache,
+                                                                        uint32_t createInfoCount,
+                                                                        const VkComputePipelineCreateInfo* pCreateInfos,
+                                                                        const VkAllocationCallbacks* pAllocator,
+                                                                        VkPipeline* pPipelines);
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateGraphicsPipelines<user_tag>(
-    VkDevice device,
-    VkPipelineCache pipelineCache,
-    uint32_t createInfoCount,
-    const VkGraphicsPipelineCreateInfo* pCreateInfos,
-    const VkAllocationCallbacks* pAllocator,
-    VkPipeline* pPipelines);
+VKAPI_ATTR VkResult VKAPI_CALL
+    layer_vkCreateGraphicsPipelines<user_tag>(VkDevice device,
+                                              VkPipelineCache pipelineCache,
+                                              uint32_t createInfoCount,
+                                              const VkGraphicsPipelineCreateInfo* pCreateInfos,
+                                              const VkAllocationCallbacks* pAllocator,
+                                              VkPipeline* pPipelines);
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateRayTracingPipelinesKHR<user_tag>(
-    VkDevice device,
-    VkDeferredOperationKHR deferredOperation,
-    VkPipelineCache pipelineCache,
-    uint32_t createInfoCount,
-    const VkRayTracingPipelineCreateInfoKHR* pCreateInfos,
-    const VkAllocationCallbacks* pAllocator,
-    VkPipeline* pPipelines);
+VKAPI_ATTR VkResult VKAPI_CALL
+    layer_vkCreateRayTracingPipelinesKHR<user_tag>(VkDevice device,
+                                                   VkDeferredOperationKHR deferredOperation,
+                                                   VkPipelineCache pipelineCache,
+                                                   uint32_t createInfoCount,
+                                                   const VkRayTracingPipelineCreateInfoKHR* pCreateInfos,
+                                                   const VkAllocationCallbacks* pAllocator,
+                                                   VkPipeline* pPipelines);
 
 // Functions for images
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateImage<user_tag>(
-    VkDevice device,
-    const VkImageCreateInfo* pCreateInfo,
-    const VkAllocationCallbacks* pAllocator,
-    VkImage* pImage);
+template<>
+VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateImage<user_tag>(VkDevice device,
+                                                             const VkImageCreateInfo* pCreateInfo,
+                                                             const VkAllocationCallbacks* pAllocator,
+                                                             VkImage* pImage);

--- a/layer_gpu_support/source/layer_device_functions_queue.cpp
+++ b/layer_gpu_support/source/layer_device_functions_queue.cpp
@@ -23,25 +23,22 @@
  * ----------------------------------------------------------------------------
  */
 
-#include <mutex>
-
 #include "device.hpp"
-#include "layer_device_functions.hpp"
+#include "framework/device_dispatch_table.hpp"
+
+#include <mutex>
 
 extern std::mutex g_vulkanLock;
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit<user_tag>(
-    VkQueue queue,
-    uint32_t submitCount,
-    const VkSubmitInfo* pSubmits,
-    VkFence fence
-) {
+VKAPI_ATTR VkResult VKAPI_CALL
+    layer_vkQueueSubmit<user_tag>(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(queue);
 
     // Serialize in the order submits are called
@@ -60,7 +57,7 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit<user_tag>(
         .waitSemaphoreValueCount = 1,
         .pWaitSemaphoreValues = &waitValue,
         .signalSemaphoreValueCount = 1,
-        .pSignalSemaphoreValues = &signalValue
+        .pSignalSemaphoreValues = &signalValue,
     };
 
     VkSubmitInfo submitInfoPre {
@@ -72,7 +69,7 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit<user_tag>(
         .commandBufferCount = 0,
         .pCommandBuffers = 0,
         .signalSemaphoreCount = 0,
-        .pSignalSemaphores = nullptr
+        .pSignalSemaphores = nullptr,
     };
 
     VkSubmitInfo submitInfoPost {
@@ -84,7 +81,7 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit<user_tag>(
         .commandBufferCount = 0,
         .pCommandBuffers = 0,
         .signalSemaphoreCount = 1,
-        .pSignalSemaphores = &(layer->queueSerializationTimelineSem)
+        .pSignalSemaphores = &(layer->queueSerializationTimelineSem),
     };
 
     // Release the lock to call into the driver
@@ -107,16 +104,13 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit<user_tag>(
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit2<user_tag>(
-    VkQueue queue,
-    uint32_t submitCount,
-    const VkSubmitInfo2* pSubmits,
-    VkFence fence
-) {
+VKAPI_ATTR VkResult VKAPI_CALL
+    layer_vkQueueSubmit2<user_tag>(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(queue);
 
     // Serialize in the order submits are called
@@ -133,7 +127,7 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit2<user_tag>(
         .semaphore = layer->queueSerializationTimelineSem,
         .value = waitValue,
         .stageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-        .deviceIndex = 0
+        .deviceIndex = 0,
     };
 
     VkSemaphoreSubmitInfo timelineInfoPost {
@@ -142,7 +136,7 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit2<user_tag>(
         .semaphore = layer->queueSerializationTimelineSem,
         .value = signalValue,
         .stageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-        .deviceIndex = 0
+        .deviceIndex = 0,
     };
 
     VkSubmitInfo2 submitInfoPre {
@@ -154,7 +148,7 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit2<user_tag>(
         .commandBufferInfoCount = 0,
         .pCommandBufferInfos = nullptr,
         .signalSemaphoreInfoCount = 0,
-        .pSignalSemaphoreInfos = nullptr
+        .pSignalSemaphoreInfos = nullptr,
     };
 
     VkSubmitInfo2 submitInfoPost {
@@ -166,7 +160,7 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit2<user_tag>(
         .commandBufferInfoCount = 0,
         .pCommandBufferInfos = nullptr,
         .signalSemaphoreInfoCount = 1,
-        .pSignalSemaphoreInfos = &timelineInfoPost
+        .pSignalSemaphoreInfos = &timelineInfoPost,
     };
 
     // Release the lock to call into the driver
@@ -185,21 +179,17 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit2<user_tag>(
     }
 
     return result;
-
 }
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit2KHR<user_tag>(
-    VkQueue queue,
-    uint32_t submitCount,
-    const VkSubmitInfo2* pSubmits,
-    VkFence fence
-) {
+VKAPI_ATTR VkResult VKAPI_CALL
+    layer_vkQueueSubmit2KHR<user_tag>(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(queue);
 
     // Serialize in the order submits are called
@@ -216,7 +206,7 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit2KHR<user_tag>(
         .semaphore = layer->queueSerializationTimelineSem,
         .value = waitValue,
         .stageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-        .deviceIndex = 0
+        .deviceIndex = 0,
     };
 
     VkSemaphoreSubmitInfo timelineInfoPost {
@@ -225,7 +215,7 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit2KHR<user_tag>(
         .semaphore = layer->queueSerializationTimelineSem,
         .value = signalValue,
         .stageMask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-        .deviceIndex = 0
+        .deviceIndex = 0,
     };
 
     VkSubmitInfo2 submitInfoPre {
@@ -237,7 +227,7 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit2KHR<user_tag>(
         .commandBufferInfoCount = 0,
         .pCommandBufferInfos = nullptr,
         .signalSemaphoreInfoCount = 0,
-        .pSignalSemaphoreInfos = nullptr
+        .pSignalSemaphoreInfos = nullptr,
     };
 
     VkSubmitInfo2 submitInfoPost {
@@ -249,7 +239,7 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit2KHR<user_tag>(
         .commandBufferInfoCount = 0,
         .pCommandBufferInfos = nullptr,
         .signalSemaphoreInfoCount = 1,
-        .pSignalSemaphoreInfos = &timelineInfoPost
+        .pSignalSemaphoreInfos = &timelineInfoPost,
     };
 
     // Release the lock to call into the driver

--- a/layer_gpu_support/source/layer_device_functions_render_pass.cpp
+++ b/layer_gpu_support/source/layer_device_functions_render_pass.cpp
@@ -23,10 +23,10 @@
  * ----------------------------------------------------------------------------
  */
 
-#include <mutex>
-
 #include "device.hpp"
-#include "layer_device_functions.hpp"
+#include "framework/device_dispatch_table.hpp"
+
+#include <mutex>
 
 extern std::mutex g_vulkanLock;
 
@@ -42,24 +42,24 @@ static std::unordered_map<VkCommandBuffer, bool> dynamic_suspend_state;
  * @param layer           The layer context for the device.
  * @param commandBuffer   The command buffer we are recording.
  */
-static void preRenderPass(
-    Device* layer,
-    VkCommandBuffer commandBuffer
-) {
+static void preRenderPass(Device* layer, VkCommandBuffer commandBuffer)
+{
     if (!layer->instance->config.serialize_cmdstream_render_pass_pre())
     {
         return;
     }
 
     // Execution dependency
-    layer->driver.vkCmdPipelineBarrier(
-        commandBuffer,
-        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-        0,
-        0, nullptr,
-        0, nullptr,
-        0, nullptr);
+    layer->driver.vkCmdPipelineBarrier(commandBuffer,
+                                       VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                                       VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                                       0,
+                                       0,
+                                       nullptr,
+                                       0,
+                                       nullptr,
+                                       0,
+                                       nullptr);
 }
 
 /**
@@ -68,37 +68,36 @@ static void preRenderPass(
  * @param layer           The layer context for the device.
  * @param commandBuffer   The command buffer we are recording.
  */
-static void postRenderPass(
-    Device* layer,
-    VkCommandBuffer commandBuffer
-) {
+static void postRenderPass(Device* layer, VkCommandBuffer commandBuffer)
+{
     if (!layer->instance->config.serialize_cmdstream_render_pass_post())
     {
         return;
     }
 
     // Execution dependency
-    layer->driver.vkCmdPipelineBarrier(
-        commandBuffer,
-        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-        0,
-        0, nullptr,
-        0, nullptr,
-        0, nullptr);
+    layer->driver.vkCmdPipelineBarrier(commandBuffer,
+                                       VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                                       VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                                       0,
+                                       0,
+                                       nullptr,
+                                       0,
+                                       nullptr,
+                                       0,
+                                       nullptr);
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderPassBeginInfo* pRenderPassBegin,
-    VkSubpassContents contents
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass<user_tag>(VkCommandBuffer commandBuffer,
+                                                                const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                                VkSubpassContents contents)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver
@@ -109,16 +108,15 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderPassBeginInfo* pRenderPassBegin,
-    const VkSubpassBeginInfo* pSubpassBeginInfo
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2<user_tag>(VkCommandBuffer commandBuffer,
+                                                                 const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                                 const VkSubpassBeginInfo* pSubpassBeginInfo)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver
@@ -129,16 +127,15 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2KHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderPassBeginInfo* pRenderPassBegin,
-    const VkSubpassBeginInfo* pSubpassBeginInfo
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2KHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                    const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                                    const VkSubpassBeginInfo* pSubpassBeginInfo)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver
@@ -149,15 +146,14 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2KHR<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRendering<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderingInfo* pRenderingInfo
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRendering<user_tag>(VkCommandBuffer commandBuffer,
+                                                               const VkRenderingInfo* pRenderingInfo)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     bool resuming = pRenderingInfo->flags & VK_RENDERING_RESUMING_BIT;
@@ -176,15 +172,14 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRendering<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderingKHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderingInfo* pRenderingInfo
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderingKHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                  const VkRenderingInfo* pRenderingInfo)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     bool resuming = pRenderingInfo->flags & VK_RENDERING_RESUMING_BIT_KHR;
@@ -203,14 +198,13 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderingKHR<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderPass<user_tag>(
-    VkCommandBuffer commandBuffer
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderPass<user_tag>(VkCommandBuffer commandBuffer)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver
@@ -221,14 +215,13 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderPass<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL  layer_vkCmdEndRendering<user_tag>(
-    VkCommandBuffer commandBuffer
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRendering<user_tag>(VkCommandBuffer commandBuffer)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Retrieve the begin rendering suspend state
@@ -248,14 +241,13 @@ VKAPI_ATTR void VKAPI_CALL  layer_vkCmdEndRendering<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL  layer_vkCmdEndRenderingKHR<user_tag>(
-    VkCommandBuffer commandBuffer
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderingKHR<user_tag>(VkCommandBuffer commandBuffer)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Retrieve the begin rendering suspend state

--- a/layer_gpu_support/source/layer_device_functions_transfer.cpp
+++ b/layer_gpu_support/source/layer_device_functions_transfer.cpp
@@ -23,10 +23,10 @@
  * ----------------------------------------------------------------------------
  */
 
-#include <mutex>
-
 #include "device.hpp"
-#include "layer_device_functions.hpp"
+#include "framework/device_dispatch_table.hpp"
+
+#include <mutex>
 
 extern std::mutex g_vulkanLock;
 
@@ -36,24 +36,24 @@ extern std::mutex g_vulkanLock;
  * @param layer           The layer context for the device.
  * @param commandBuffer   The command buffer we are recording.
  */
-static void preTransfer(
-    Device* layer,
-    VkCommandBuffer commandBuffer
-) {
+static void preTransfer(Device* layer, VkCommandBuffer commandBuffer)
+{
     if (!layer->instance->config.serialize_cmdstream_transfer_pre())
     {
         return;
     }
 
     // Execution dependency
-    layer->driver.vkCmdPipelineBarrier(
-        commandBuffer,
-        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-        0,
-        0, nullptr,
-        0, nullptr,
-        0, nullptr);
+    layer->driver.vkCmdPipelineBarrier(commandBuffer,
+                                       VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                                       VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                                       0,
+                                       0,
+                                       nullptr,
+                                       0,
+                                       nullptr,
+                                       0,
+                                       nullptr);
 }
 
 /**
@@ -62,41 +62,40 @@ static void preTransfer(
  * @param layer           The layer context for the device.
  * @param commandBuffer   The command buffer we are recording.
  */
-static void postTransfer(
-    Device* layer,
-    VkCommandBuffer commandBuffer
-) {
+static void postTransfer(Device* layer, VkCommandBuffer commandBuffer)
+{
     if (!layer->instance->config.serialize_cmdstream_transfer_post())
     {
         return;
     }
 
     // Execution dependency
-    layer->driver.vkCmdPipelineBarrier(
-        commandBuffer,
-        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-        VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
-        0,
-        0, nullptr,
-        0, nullptr,
-        0, nullptr);
+    layer->driver.vkCmdPipelineBarrier(commandBuffer,
+                                       VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                                       VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                                       0,
+                                       0,
+                                       nullptr,
+                                       0,
+                                       nullptr,
+                                       0,
+                                       nullptr);
 }
 
 // Commands for transfers
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdFillBuffer<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer dstBuffer,
-    VkDeviceSize dstOffset,
-    VkDeviceSize size,
-    uint32_t data
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdFillBuffer<user_tag>(VkCommandBuffer commandBuffer,
+                                                           VkBuffer dstBuffer,
+                                                           VkDeviceSize dstOffset,
+                                                           VkDeviceSize size,
+                                                           uint32_t data)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver
@@ -108,19 +107,18 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdFillBuffer<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdClearColorImage<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkImage image,
-    VkImageLayout imageLayout,
-    const VkClearColorValue* pColor,
-    uint32_t rangeCount,
-    const VkImageSubresourceRange* pRanges
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdClearColorImage<user_tag>(VkCommandBuffer commandBuffer,
+                                                                VkImage image,
+                                                                VkImageLayout imageLayout,
+                                                                const VkClearColorValue* pColor,
+                                                                uint32_t rangeCount,
+                                                                const VkImageSubresourceRange* pRanges)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver
@@ -132,19 +130,18 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdClearColorImage<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdClearDepthStencilImage<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkImage image,
-    VkImageLayout imageLayout,
-    const VkClearDepthStencilValue* pDepthStencil,
-    uint32_t rangeCount,
-    const VkImageSubresourceRange* pRanges
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdClearDepthStencilImage<user_tag>(VkCommandBuffer commandBuffer,
+                                                                       VkImage image,
+                                                                       VkImageLayout imageLayout,
+                                                                       const VkClearDepthStencilValue* pDepthStencil,
+                                                                       uint32_t rangeCount,
+                                                                       const VkImageSubresourceRange* pRanges)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver
@@ -156,18 +153,17 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdClearDepthStencilImage<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer srcBuffer,
-    VkBuffer dstBuffer,
-    uint32_t regionCount,
-    const VkBufferCopy* pRegions
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer<user_tag>(VkCommandBuffer commandBuffer,
+                                                           VkBuffer srcBuffer,
+                                                           VkBuffer dstBuffer,
+                                                           uint32_t regionCount,
+                                                           const VkBufferCopy* pRegions)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver
@@ -179,15 +175,14 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer2<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyBufferInfo2* pCopyBufferInfo
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer2<user_tag>(VkCommandBuffer commandBuffer,
+                                                            const VkCopyBufferInfo2* pCopyBufferInfo)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver
@@ -199,15 +194,14 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer2<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer2KHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyBufferInfo2* pCopyBufferInfo
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer2KHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                               const VkCopyBufferInfo2* pCopyBufferInfo)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver
@@ -219,19 +213,18 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer2KHR<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBufferToImage<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer srcBuffer,
-    VkImage dstImage,
-    VkImageLayout dstImageLayout,
-    uint32_t regionCount,
-    const VkBufferImageCopy* pRegions
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBufferToImage<user_tag>(VkCommandBuffer commandBuffer,
+                                                                  VkBuffer srcBuffer,
+                                                                  VkImage dstImage,
+                                                                  VkImageLayout dstImageLayout,
+                                                                  uint32_t regionCount,
+                                                                  const VkBufferImageCopy* pRegions)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver
@@ -243,15 +236,15 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBufferToImage<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBufferToImage2<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL
+    layer_vkCmdCopyBufferToImage2<user_tag>(VkCommandBuffer commandBuffer,
+                                            const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver
@@ -263,15 +256,15 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBufferToImage2<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBufferToImage2KHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL
+    layer_vkCmdCopyBufferToImage2KHR<user_tag>(VkCommandBuffer commandBuffer,
+                                               const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver
@@ -283,40 +276,39 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBufferToImage2KHR<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkImage srcImage,
-    VkImageLayout srcImageLayout,
-    VkImage dstImage,
-    VkImageLayout dstImageLayout,
-    uint32_t regionCount,
-    const VkImageCopy* pRegions
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage<user_tag>(VkCommandBuffer commandBuffer,
+                                                          VkImage srcImage,
+                                                          VkImageLayout srcImageLayout,
+                                                          VkImage dstImage,
+                                                          VkImageLayout dstImageLayout,
+                                                          uint32_t regionCount,
+                                                          const VkImageCopy* pRegions)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver
     lock.unlock();
 
     preTransfer(layer, commandBuffer);
-    layer->driver.vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
+    layer->driver
+        .vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
     postTransfer(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage2<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyImageInfo2* pCopyImageInfo
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage2<user_tag>(VkCommandBuffer commandBuffer,
+                                                           const VkCopyImageInfo2* pCopyImageInfo)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver
@@ -328,15 +320,14 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage2<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage2KHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyImageInfo2* pCopyImageInfo
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage2KHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                              const VkCopyImageInfo2* pCopyImageInfo)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver
@@ -348,19 +339,18 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage2KHR<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImageToBuffer<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkImage srcImage,
-    VkImageLayout srcImageLayout,
-    VkBuffer dstBuffer,
-    uint32_t regionCount,
-    const VkBufferImageCopy* pRegions
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImageToBuffer<user_tag>(VkCommandBuffer commandBuffer,
+                                                                  VkImage srcImage,
+                                                                  VkImageLayout srcImageLayout,
+                                                                  VkBuffer dstBuffer,
+                                                                  uint32_t regionCount,
+                                                                  const VkBufferImageCopy* pRegions)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver
@@ -372,15 +362,15 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImageToBuffer<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImageToBuffer2<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL
+    layer_vkCmdCopyImageToBuffer2<user_tag>(VkCommandBuffer commandBuffer,
+                                            const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver
@@ -392,15 +382,15 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImageToBuffer2<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImageToBuffer2KHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL
+    layer_vkCmdCopyImageToBuffer2KHR<user_tag>(VkCommandBuffer commandBuffer,
+                                               const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Release the lock to call into the driver

--- a/layer_gpu_timeline/CMakeLists.txt
+++ b/layer_gpu_timeline/CMakeLists.txt
@@ -33,6 +33,7 @@ set(LGL_CONFIG_TRACE 0)
 set(LGL_CONFIG_LOG 1)
 
 include(../source_common/compiler_helper.cmake)
+include(../cmake/clang-tools.cmake)
 
 # Build steps
 add_subdirectory(../source_common/comms source_common/comms)

--- a/layer_gpu_timeline/source/CMakeLists.txt
+++ b/layer_gpu_timeline/source/CMakeLists.txt
@@ -83,3 +83,5 @@ if (CMAKE_BUILD_TYPE STREQUAL "Release")
         ARGS --strip-all -o ${VK_LAYER_STRIP} $<TARGET_FILE:${VK_LAYER}>
         COMMENT "Stripped lib${VK_LAYER}.so to ${VK_LAYER_STRIP}")
 endif()
+
+add_clang_tools()

--- a/layer_gpu_timeline/source/device.cpp
+++ b/layer_gpu_timeline/source/device.cpp
@@ -23,19 +23,20 @@
  * ----------------------------------------------------------------------------
  */
 
-#include <array>
-#include <iostream>
-#include <fstream>
-#include <nlohmann/json.hpp>
-#include <sys/stat.h>
-#include <unistd.h>
-#include <vector>
+#include "device.hpp"
 
 #include "comms/comms_module.hpp"
 #include "framework/utils.hpp"
-
-#include "device.hpp"
 #include "instance.hpp"
+
+#include <array>
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+#include <sys/stat.h>
+#include <unistd.h>
 
 using json = nlohmann::json;
 
@@ -45,7 +46,7 @@ using json = nlohmann::json;
 static std::unordered_map<void*, std::unique_ptr<Device>> g_devices;
 
 /* See header for documentation. */
-const std::vector<std::string> Device::extraExtensions { };
+const std::vector<std::string> Device::extraExtensions {};
 
 /* See header for documentation. */
 std::unique_ptr<Comms::CommsModule> Device::commsModule;
@@ -54,59 +55,51 @@ std::unique_ptr<Comms::CommsModule> Device::commsModule;
 std::unique_ptr<TimelineComms> Device::commsWrapper;
 
 /* See header for documentation. */
-void Device::store(
-    VkDevice handle,
-    std::unique_ptr<Device> device
-) {
+void Device::store(VkDevice handle, std::unique_ptr<Device> device)
+{
     void* key = getDispatchKey(handle);
-    g_devices.insert({ key, std::move(device) });
+    g_devices.insert({key, std::move(device)});
 }
 
 /* See header for documentation. */
-Device* Device::retrieve(
-    VkDevice handle
-) {
+Device* Device::retrieve(VkDevice handle)
+{
     void* key = getDispatchKey(handle);
     assert(isInMap(key, g_devices));
     return g_devices.at(key).get();
 }
 
 /* See header for documentation. */
-Device* Device::retrieve(
-    VkQueue handle
-) {
+Device* Device::retrieve(VkQueue handle)
+{
     void* key = getDispatchKey(handle);
     assert(isInMap(key, g_devices));
     return g_devices.at(key).get();
 }
 
 /* See header for documentation. */
-Device* Device::retrieve(
-    VkCommandBuffer handle
-) {
+Device* Device::retrieve(VkCommandBuffer handle)
+{
     void* key = getDispatchKey(handle);
     assert(isInMap(key, g_devices));
     return g_devices.at(key).get();
 }
 
 /* See header for documentation. */
-void Device::destroy(
-    Device* device
-) {
+void Device::destroy(Device* device)
+{
     g_devices.erase(getDispatchKey(device));
 }
 
 /* See header for documentation. */
-Device::Device(
-    Instance* _instance,
-    VkPhysicalDevice _physicalDevice,
-    VkDevice _device,
-    PFN_vkGetDeviceProcAddr nlayerGetProcAddress,
-    const VkDeviceCreateInfo& createInfo
-):
-    instance(_instance),
-    physicalDevice(_physicalDevice),
-    device(_device)
+Device::Device(Instance* _instance,
+               VkPhysicalDevice _physicalDevice,
+               VkDevice _device,
+               PFN_vkGetDeviceProcAddr nlayerGetProcAddress,
+               const VkDeviceCreateInfo& createInfo)
+    : instance(_instance),
+      physicalDevice(_physicalDevice),
+      device(_device)
 {
     UNUSED(createInfo);
 
@@ -123,7 +116,7 @@ Device::Device(
     VkPhysicalDeviceProperties deviceProperties;
     instance->driver.vkGetPhysicalDeviceProperties(physicalDevice, &deviceProperties);
 
-    std::string name { deviceProperties.deviceName };
+    std::string name {deviceProperties.deviceName};
 
     uint32_t driverVersion = deviceProperties.driverVersion;
     uint32_t major = VK_VERSION_MAJOR(driverVersion);
@@ -133,13 +126,13 @@ Device::Device(
     pid_t processPID = getpid();
 
     json deviceMetadata {
-        { "type", "device" },
-        { "pid", static_cast<uint32_t>(processPID) },
-        { "device", reinterpret_cast<uintptr_t>(device) },
-        { "deviceName", name },
-        { "driverMajor", major },
-        { "driverMinor", minor },
-        { "driverPatch", patch }
+        {"type", "device"},
+        {"pid", static_cast<uint32_t>(processPID)},
+        {"device", reinterpret_cast<uintptr_t>(device)},
+        {"deviceName", name},
+        {"driverMajor", major},
+        {"driverMinor", minor},
+        {"driverPatch", patch},
     };
 
     commsWrapper->txMessage(deviceMetadata.dump());

--- a/layer_gpu_timeline/source/device.hpp
+++ b/layer_gpu_timeline/source/device.hpp
@@ -52,14 +52,13 @@
 
 #pragma once
 
-#include <vulkan/vk_layer.h>
-
 #include "comms/comms_module.hpp"
 #include "framework/device_dispatch_table.hpp"
-#include "trackers/device.hpp"
-
 #include "instance.hpp"
 #include "timeline_comms.hpp"
+#include "trackers/device.hpp"
+
+#include <vulkan/vk_layer.h>
 
 /**
  * @brief This class implements the layer state tracker for a single device.
@@ -73,9 +72,7 @@ public:
      * @param handle   The dispatchable device handle to use as an indirect key.
      * @param device   The @c Device object to store.
      */
-    static void store(
-        VkDevice handle,
-        std::unique_ptr<Device> device);
+    static void store(VkDevice handle, std::unique_ptr<Device> device);
 
     /**
      * @brief Fetch a device from the global store of dispatchable devices.
@@ -84,8 +81,7 @@ public:
      *
      * @return The layer device context.
      */
-    static Device* retrieve(
-        VkDevice handle);
+    static Device* retrieve(VkDevice handle);
 
     /**
      * @brief Fetch a device from the global store of dispatchable devices.
@@ -94,8 +90,7 @@ public:
      *
      * @return The layer device context.
      */
-    static Device* retrieve(
-        VkQueue handle);
+    static Device* retrieve(VkQueue handle);
 
     /**
      * @brief Fetch a device from the global store of dispatchable devices.
@@ -104,16 +99,14 @@ public:
      *
      * @return The layer device context.
      */
-    static Device* retrieve(
-        VkCommandBuffer handle);
+    static Device* retrieve(VkCommandBuffer handle);
 
     /**
      * @brief Drop a device from the global store of dispatchable devices.
      *
      * @param device   The device to drop.
      */
-    static void destroy(
-        Device* device);
+    static void destroy(Device* device);
 
     /**
      * @brief Create a new layer device object.
@@ -126,12 +119,11 @@ public:
      * @param nlayerGetProcAddress   The vkGetDeviceProcAddress function for the driver.
      * @param createInfo             The create info used to create the device.
      */
-    Device(
-        Instance* instance,
-        VkPhysicalDevice physicalDevice,
-        VkDevice device,
-        PFN_vkGetDeviceProcAddr nlayerGetProcAddress,
-        const VkDeviceCreateInfo& createInfo);
+    Device(Instance* instance,
+           VkPhysicalDevice physicalDevice,
+           VkDevice device,
+           PFN_vkGetDeviceProcAddr nlayerGetProcAddress,
+           const VkDeviceCreateInfo& createInfo);
 
     /**
      * @brief Destroy this layer device object.
@@ -143,30 +135,19 @@ public:
      *
      * @param message   The message to send.
      */
-    void onFrame(
-        const std::string& message
-    ) {
-        commsWrapper->txMessage(message);
-    }
+    void onFrame(const std::string& message) { commsWrapper->txMessage(message); }
 
     /**
      * @brief Callback for sending messages on workload submit to a queue.
      *
      * @param message   The message to send.
      */
-    void onWorkloadSubmit(
-        const std::string& message
-    ) {
-        commsWrapper->txMessage(message);
-    }
+    void onWorkloadSubmit(const std::string& message) { commsWrapper->txMessage(message); }
 
     /**
      * @brief Get the cumulative stats for this device.
      */
-    Tracker::Device& getStateTracker()
-    {
-        return stateTracker;
-    }
+    Tracker::Device& getStateTracker() { return stateTracker; }
 
 public:
     /**

--- a/layer_gpu_timeline/source/device_utils.hpp
+++ b/layer_gpu_timeline/source/device_utils.hpp
@@ -25,11 +25,10 @@
 
 #pragma once
 
-#include <vulkan/vulkan.h>
-
+#include "device.hpp"
 #include "framework/utils.hpp"
 
-#include "device.hpp"
+#include <vulkan/vulkan.h>
 
 /**
  * @brief Emit a start tag via a driver debug utils label.
@@ -38,18 +37,15 @@
  * @param commandBuffer   The command buffer we are recording.
  * @param tagID           The tagID to emit into the label.
  */
-[[maybe_unused]] static void emitStartTag(
-    Device* layer,
-    VkCommandBuffer commandBuffer,
-    uint64_t tagID
-) {
+[[maybe_unused]] static void emitStartTag(Device* layer, VkCommandBuffer commandBuffer, uint64_t tagID)
+{
     // Emit the unique workload tag into the command stream
     std::string tagLabel = formatString("t%" PRIu64, tagID);
     VkDebugUtilsLabelEXT tagInfo {
         .sType = VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT,
         .pNext = nullptr,
         .pLabelName = tagLabel.c_str(),
-        .color = { 0.0f, 0.0f, 0.0f, 0.0f }
+        .color = {0.0f, 0.0f, 0.0f, 0.0f},
     };
 
     layer->driver.vkCmdBeginDebugUtilsLabelEXT(commandBuffer, &tagInfo);

--- a/layer_gpu_timeline/source/instance.cpp
+++ b/layer_gpu_timeline/source/instance.cpp
@@ -23,11 +23,11 @@
  * ----------------------------------------------------------------------------
  */
 
-#include <cassert>
+#include "instance.hpp"
 
 #include "framework/utils.hpp"
 
-#include "instance.hpp"
+#include <cassert>
 
 /**
  * @brief The dispatch lookup for all of the created Vulkan instances.
@@ -35,54 +35,46 @@
 static std::unordered_map<void*, std::unique_ptr<Instance>> g_instances;
 
 /* See header for documentation. */
-const APIVersion Instance::minAPIVersion { 1, 1 };
+const APIVersion Instance::minAPIVersion {1, 1};
 
 /* See header for documentation. */
 const std::vector<std::string> Instance::extraExtensions {
-    VK_EXT_DEBUG_UTILS_EXTENSION_NAME
+    VK_EXT_DEBUG_UTILS_EXTENSION_NAME,
 };
 
 /* See header for documentation. */
-void Instance::store(
-    VkInstance handle,
-    std::unique_ptr<Instance>& instance
-) {
+void Instance::store(VkInstance handle, std::unique_ptr<Instance>& instance)
+{
     void* key = getDispatchKey(handle);
-    g_instances.insert({ key, std::move(instance) });
+    g_instances.insert({key, std::move(instance)});
 }
 
 /* See header for documentation. */
-Instance* Instance::retrieve(
-    VkInstance handle
-) {
+Instance* Instance::retrieve(VkInstance handle)
+{
     void* key = getDispatchKey(handle);
     assert(isInMap(key, g_instances));
     return g_instances.at(key).get();
 }
 
 /* See header for documentation. */
-Instance* Instance::retrieve(
-    VkPhysicalDevice handle
-) {
+Instance* Instance::retrieve(VkPhysicalDevice handle)
+{
     void* key = getDispatchKey(handle);
     assert(isInMap(key, g_instances));
     return g_instances.at(key).get();
 }
 
 /* See header for documentation. */
-void Instance::destroy(
-    Instance* instance
-) {
+void Instance::destroy(Instance* instance)
+{
     g_instances.erase(getDispatchKey(instance->instance));
 }
 
 /* See header for documentation. */
-Instance::Instance(
-    VkInstance _instance,
-    PFN_vkGetInstanceProcAddr _nlayerGetProcAddress
-) :
-    instance(_instance),
-    nlayerGetProcAddress(_nlayerGetProcAddress)
+Instance::Instance(VkInstance _instance, PFN_vkGetInstanceProcAddr _nlayerGetProcAddress)
+    : instance(_instance),
+      nlayerGetProcAddress(_nlayerGetProcAddress)
 {
     initDriverInstanceDispatchTable(instance, nlayerGetProcAddress, driver);
 }

--- a/layer_gpu_timeline/source/instance.hpp
+++ b/layer_gpu_timeline/source/instance.hpp
@@ -54,13 +54,13 @@
 
 #pragma once
 
+#include "framework/instance_dispatch_table.hpp"
+
 #include <memory>
 #include <unordered_map>
 
 #include <vulkan/vk_layer.h>
 #include <vulkan/vulkan.h>
-
-#include "framework/instance_dispatch_table.hpp"
 
 /**
  * @brief This class implements the layer state tracker for a single instance.
@@ -74,9 +74,7 @@ public:
      * @param handle     The dispatchable instance handle to use as an indirect key.
      * @param instance   The @c Instance object to store.
      */
-    static void store(
-        VkInstance handle,
-        std::unique_ptr<Instance>& instance);
+    static void store(VkInstance handle, std::unique_ptr<Instance>& instance);
 
     /**
      * @brief Fetch an instance from the global store of dispatchable instances.
@@ -85,8 +83,7 @@ public:
      *
      * @return The layer instance context.
      */
-    static Instance* retrieve(
-        VkInstance handle);
+    static Instance* retrieve(VkInstance handle);
 
     /**
      * @brief Fetch an instance from the global store of dispatchable instances.
@@ -95,16 +92,14 @@ public:
      *
      * @return The layer instance context.
      */
-    static Instance* retrieve(
-        VkPhysicalDevice handle);
+    static Instance* retrieve(VkPhysicalDevice handle);
 
     /**
      * @brief Drop an instance from the global store of dispatchable instances.
      *
      * @param instance   The instance to drop.
      */
-    static void destroy(
-        Instance* instance);
+    static void destroy(Instance* instance);
 
     /**
      * @brief Create a new layer instance object.
@@ -112,9 +107,7 @@ public:
      * @param instance               The instance handle this instance is created with.
      * @param nlayerGetProcAddress   The vkGetProcAddress function in the driver/next layer down.
      */
-    Instance(
-        VkInstance instance,
-        PFN_vkGetInstanceProcAddr nlayerGetProcAddress);
+    Instance(VkInstance instance, PFN_vkGetInstanceProcAddr nlayerGetProcAddress);
 
 public:
     /**

--- a/layer_gpu_timeline/source/layer_device_functions.hpp
+++ b/layer_gpu_timeline/source/layer_device_functions.hpp
@@ -27,484 +27,424 @@
 
 #include <vulkan/vulkan.h>
 
-#include "framework/utils.hpp"
-
 // Functions for command pools
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateCommandPool<user_tag>(
-    VkDevice device,
-    const VkCommandPoolCreateInfo* pCreateInfo,
-    const VkAllocationCallbacks* pAllocator,
-    VkCommandPool* pCommandPool);
+template<>
+VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateCommandPool<user_tag>(VkDevice device,
+                                                                   const VkCommandPoolCreateInfo* pCreateInfo,
+                                                                   const VkAllocationCallbacks* pAllocator,
+                                                                   VkCommandPool* pCommandPool);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkResetCommandPool<user_tag>(
-    VkDevice device,
-    VkCommandPool commandPool,
-    VkCommandPoolResetFlags flags);
+template<>
+VKAPI_ATTR VkResult VKAPI_CALL layer_vkResetCommandPool<user_tag>(VkDevice device,
+                                                                  VkCommandPool commandPool,
+                                                                  VkCommandPoolResetFlags flags);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkDestroyCommandPool<user_tag>(
-    VkDevice device,
-    VkCommandPool commandPool,
-    const VkAllocationCallbacks* pAllocator);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkDestroyCommandPool<user_tag>(VkDevice device,
+                                                                VkCommandPool commandPool,
+                                                                const VkAllocationCallbacks* pAllocator);
 
 // Functions for command buffers
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkAllocateCommandBuffers<user_tag>(
-    VkDevice device,
-    const VkCommandBufferAllocateInfo* pAllocateInfo,
-    VkCommandBuffer* pCommandBuffers);
+template<>
+VKAPI_ATTR VkResult VKAPI_CALL
+    layer_vkAllocateCommandBuffers<user_tag>(VkDevice device,
+                                             const VkCommandBufferAllocateInfo* pAllocateInfo,
+                                             VkCommandBuffer* pCommandBuffers);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR VkResult layer_vkBeginCommandBuffer<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCommandBufferBeginInfo* pBeginInfo);
+template<>
+VKAPI_ATTR VkResult layer_vkBeginCommandBuffer<user_tag>(VkCommandBuffer commandBuffer,
+                                                         const VkCommandBufferBeginInfo* pBeginInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdExecuteCommands<user_tag>(
-    VkCommandBuffer commandBuffer,
-    uint32_t commandBufferCount,
-    const VkCommandBuffer* pCommandBuffers);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdExecuteCommands<user_tag>(VkCommandBuffer commandBuffer,
+                                                                uint32_t commandBufferCount,
+                                                                const VkCommandBuffer* pCommandBuffers);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkResetCommandBuffer<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkCommandBufferResetFlags flags);
+template<>
+VKAPI_ATTR VkResult VKAPI_CALL layer_vkResetCommandBuffer<user_tag>(VkCommandBuffer commandBuffer,
+                                                                    VkCommandBufferResetFlags flags);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkFreeCommandBuffers<user_tag>(
-    VkDevice device,
-    VkCommandPool commandPool,
-    uint32_t commandBufferCount,
-    const VkCommandBuffer* pCommandBuffers);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkFreeCommandBuffers<user_tag>(VkDevice device,
+                                                                VkCommandPool commandPool,
+                                                                uint32_t commandBufferCount,
+                                                                const VkCommandBuffer* pCommandBuffers);
 
 // Functions for render passes
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateRenderPass<user_tag>(
-    VkDevice device,
-    const VkRenderPassCreateInfo* pCreateInfo,
-    const VkAllocationCallbacks* pAllocator,
-    VkRenderPass* pRenderPass);
+template<>
+VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateRenderPass<user_tag>(VkDevice device,
+                                                                  const VkRenderPassCreateInfo* pCreateInfo,
+                                                                  const VkAllocationCallbacks* pAllocator,
+                                                                  VkRenderPass* pRenderPass);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateRenderPass2<user_tag>(
-    VkDevice device,
-    const VkRenderPassCreateInfo2* pCreateInfo,
-    const VkAllocationCallbacks* pAllocator,
-    VkRenderPass* pRenderPass);
+template<>
+VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateRenderPass2<user_tag>(VkDevice device,
+                                                                   const VkRenderPassCreateInfo2* pCreateInfo,
+                                                                   const VkAllocationCallbacks* pAllocator,
+                                                                   VkRenderPass* pRenderPass);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateRenderPass2KHR<user_tag>(
-    VkDevice device,
-    const VkRenderPassCreateInfo2* pCreateInfo,
-    const VkAllocationCallbacks* pAllocator,
-    VkRenderPass* pRenderPass);
+template<>
+VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateRenderPass2KHR<user_tag>(VkDevice device,
+                                                                      const VkRenderPassCreateInfo2* pCreateInfo,
+                                                                      const VkAllocationCallbacks* pAllocator,
+                                                                      VkRenderPass* pRenderPass);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkDestroyRenderPass<user_tag>(
-    VkDevice device,
-    VkRenderPass renderPass,
-    const VkAllocationCallbacks* pAllocator);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkDestroyRenderPass<user_tag>(VkDevice device,
+                                                               VkRenderPass renderPass,
+                                                               const VkAllocationCallbacks* pAllocator);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderPassBeginInfo* pRenderPassBegin,
-    VkSubpassContents contents);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass<user_tag>(VkCommandBuffer commandBuffer,
+                                                                const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                                VkSubpassContents contents);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderPassBeginInfo* pRenderPassBegin,
-    const VkSubpassBeginInfo* pSubpassBeginInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2<user_tag>(VkCommandBuffer commandBuffer,
+                                                                 const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                                 const VkSubpassBeginInfo* pSubpassBeginInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2KHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderPassBeginInfo* pRenderPassBegin,
-    const VkSubpassBeginInfo* pSubpassBeginInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2KHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                    const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                                    const VkSubpassBeginInfo* pSubpassBeginInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRendering<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderingInfo* pRenderingInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRendering<user_tag>(VkCommandBuffer commandBuffer,
+                                                               const VkRenderingInfo* pRenderingInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderingKHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderingInfo* pRenderingInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderingKHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                  const VkRenderingInfo* pRenderingInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderPass<user_tag>(
-    VkCommandBuffer commandBuffer);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderPass<user_tag>(VkCommandBuffer commandBuffer);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL  layer_vkCmdEndRendering<user_tag>(
-    VkCommandBuffer commandBuffer);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRendering<user_tag>(VkCommandBuffer commandBuffer);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL  layer_vkCmdEndRenderingKHR<user_tag>(
-    VkCommandBuffer commandBuffer);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderingKHR<user_tag>(VkCommandBuffer commandBuffer);
 
 // Functions for draw calls
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDraw<user_tag>(
-    VkCommandBuffer commandBuffer,
-    uint32_t vertexCount,
-    uint32_t instanceCount,
-    uint32_t firstVertex,
-    uint32_t firstInstance);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDraw<user_tag>(VkCommandBuffer commandBuffer,
+                                                     uint32_t vertexCount,
+                                                     uint32_t instanceCount,
+                                                     uint32_t firstVertex,
+                                                     uint32_t firstInstance);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndexed<user_tag>(
-    VkCommandBuffer commandBuffer,
-    uint32_t indexCount,
-    uint32_t instanceCount,
-    uint32_t firstIndex,
-    int32_t vertexOffset,
-    uint32_t firstInstance);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndexed<user_tag>(VkCommandBuffer commandBuffer,
+                                                            uint32_t indexCount,
+                                                            uint32_t instanceCount,
+                                                            uint32_t firstIndex,
+                                                            int32_t vertexOffset,
+                                                            uint32_t firstInstance);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndexedIndirect<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer buffer,
-    VkDeviceSize offset,
-    uint32_t drawCount,
-    uint32_t stride);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndexedIndirect<user_tag>(VkCommandBuffer commandBuffer,
+                                                                    VkBuffer buffer,
+                                                                    VkDeviceSize offset,
+                                                                    uint32_t drawCount,
+                                                                    uint32_t stride);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndexedIndirectCount<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer buffer,
-    VkDeviceSize offset,
-    VkBuffer countBuffer,
-    VkDeviceSize countBufferOffset,
-    uint32_t maxDrawCount,
-    uint32_t stride);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndexedIndirectCount<user_tag>(VkCommandBuffer commandBuffer,
+                                                                         VkBuffer buffer,
+                                                                         VkDeviceSize offset,
+                                                                         VkBuffer countBuffer,
+                                                                         VkDeviceSize countBufferOffset,
+                                                                         uint32_t maxDrawCount,
+                                                                         uint32_t stride);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndexedIndirectCountKHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer buffer,
-    VkDeviceSize offset,
-    VkBuffer countBuffer,
-    VkDeviceSize countBufferOffset,
-    uint32_t maxDrawCount,
-    uint32_t stride);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndexedIndirectCountKHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                            VkBuffer buffer,
+                                                                            VkDeviceSize offset,
+                                                                            VkBuffer countBuffer,
+                                                                            VkDeviceSize countBufferOffset,
+                                                                            uint32_t maxDrawCount,
+                                                                            uint32_t stride);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndirect<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer buffer,
-    VkDeviceSize offset,
-    uint32_t drawCount,
-    uint32_t stride);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndirect<user_tag>(VkCommandBuffer commandBuffer,
+                                                             VkBuffer buffer,
+                                                             VkDeviceSize offset,
+                                                             uint32_t drawCount,
+                                                             uint32_t stride);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndirectByteCountEXT<user_tag>(
-    VkCommandBuffer commandBuffer,
-    uint32_t instanceCount,
-    uint32_t firstInstance,
-    VkBuffer counterBuffer,
-    VkDeviceSize counterBufferOffset,
-    uint32_t counterOffset,
-    uint32_t vertexStride);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndirectByteCountEXT<user_tag>(VkCommandBuffer commandBuffer,
+                                                                         uint32_t instanceCount,
+                                                                         uint32_t firstInstance,
+                                                                         VkBuffer counterBuffer,
+                                                                         VkDeviceSize counterBufferOffset,
+                                                                         uint32_t counterOffset,
+                                                                         uint32_t vertexStride);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndirectCount<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer buffer,
-    VkDeviceSize offset,
-    VkBuffer countBuffer,
-    VkDeviceSize countBufferOffset,
-    uint32_t maxDrawCount,
-    uint32_t stride);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndirectCount<user_tag>(VkCommandBuffer commandBuffer,
+                                                                  VkBuffer buffer,
+                                                                  VkDeviceSize offset,
+                                                                  VkBuffer countBuffer,
+                                                                  VkDeviceSize countBufferOffset,
+                                                                  uint32_t maxDrawCount,
+                                                                  uint32_t stride);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndirectCountKHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer buffer,
-    VkDeviceSize offset,
-    VkBuffer countBuffer,
-    VkDeviceSize countBufferOffset,
-    uint32_t maxDrawCount,
-    uint32_t stride);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndirectCountKHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                     VkBuffer buffer,
+                                                                     VkDeviceSize offset,
+                                                                     VkBuffer countBuffer,
+                                                                     VkDeviceSize countBufferOffset,
+                                                                     uint32_t maxDrawCount,
+                                                                     uint32_t stride);
 
 // Functions for compute dispatches
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatch<user_tag>(
-    VkCommandBuffer commandBuffer,
-    uint32_t groupCountX,
-    uint32_t groupCountY,
-    uint32_t groupCountZ);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatch<user_tag>(VkCommandBuffer commandBuffer,
+                                                         uint32_t groupCountX,
+                                                         uint32_t groupCountY,
+                                                         uint32_t groupCountZ);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatchBase<user_tag>(
-    VkCommandBuffer commandBuffer,
-    uint32_t baseGroupX,
-    uint32_t baseGroupY,
-    uint32_t baseGroupZ,
-    uint32_t groupCountX,
-    uint32_t groupCountY,
-    uint32_t groupCountZ);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatchBase<user_tag>(VkCommandBuffer commandBuffer,
+                                                             uint32_t baseGroupX,
+                                                             uint32_t baseGroupY,
+                                                             uint32_t baseGroupZ,
+                                                             uint32_t groupCountX,
+                                                             uint32_t groupCountY,
+                                                             uint32_t groupCountZ);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatchBaseKHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    uint32_t baseGroupX,
-    uint32_t baseGroupY,
-    uint32_t baseGroupZ,
-    uint32_t groupCountX,
-    uint32_t groupCountY,
-    uint32_t groupCountZ);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatchBaseKHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                uint32_t baseGroupX,
+                                                                uint32_t baseGroupY,
+                                                                uint32_t baseGroupZ,
+                                                                uint32_t groupCountX,
+                                                                uint32_t groupCountY,
+                                                                uint32_t groupCountZ);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatchIndirect<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer buffer,
-    VkDeviceSize offset);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatchIndirect<user_tag>(VkCommandBuffer commandBuffer,
+                                                                 VkBuffer buffer,
+                                                                 VkDeviceSize offset);
 
 // Commands for trace rays
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdTraceRaysIndirect2KHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkDeviceAddress indirectDeviceAddress);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdTraceRaysIndirect2KHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                      VkDeviceAddress indirectDeviceAddress);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdTraceRaysIndirectKHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
-    const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
-    const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
-    const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
-    VkDeviceAddress indirectDeviceAddress);
+template<>
+VKAPI_ATTR void VKAPI_CALL
+    layer_vkCmdTraceRaysIndirectKHR<user_tag>(VkCommandBuffer commandBuffer,
+                                              const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
+                                              const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
+                                              const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
+                                              const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
+                                              VkDeviceAddress indirectDeviceAddress);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdTraceRaysKHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
-    const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
-    const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
-    const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
-    uint32_t width,
-    uint32_t height,
-    uint32_t depth);
-
+template<>
+VKAPI_ATTR void VKAPI_CALL
+    layer_vkCmdTraceRaysKHR<user_tag>(VkCommandBuffer commandBuffer,
+                                      const VkStridedDeviceAddressRegionKHR* pRaygenShaderBindingTable,
+                                      const VkStridedDeviceAddressRegionKHR* pMissShaderBindingTable,
+                                      const VkStridedDeviceAddressRegionKHR* pHitShaderBindingTable,
+                                      const VkStridedDeviceAddressRegionKHR* pCallableShaderBindingTable,
+                                      uint32_t width,
+                                      uint32_t height,
+                                      uint32_t depth);
 
 // Commands for transfers
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdFillBuffer<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer dstBuffer,
-    VkDeviceSize dstOffset,
-    VkDeviceSize size,
-    uint32_t data);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdFillBuffer<user_tag>(VkCommandBuffer commandBuffer,
+                                                           VkBuffer dstBuffer,
+                                                           VkDeviceSize dstOffset,
+                                                           VkDeviceSize size,
+                                                           uint32_t data);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdClearColorImage<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkImage image,
-    VkImageLayout imageLayout,
-    const VkClearColorValue* pColor,
-    uint32_t rangeCount,
-    const VkImageSubresourceRange* pRanges);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdClearColorImage<user_tag>(VkCommandBuffer commandBuffer,
+                                                                VkImage image,
+                                                                VkImageLayout imageLayout,
+                                                                const VkClearColorValue* pColor,
+                                                                uint32_t rangeCount,
+                                                                const VkImageSubresourceRange* pRanges);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdClearDepthStencilImage<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkImage image,
-    VkImageLayout imageLayout,
-    const VkClearDepthStencilValue* pDepthStencil,
-    uint32_t rangeCount,
-    const VkImageSubresourceRange* pRanges);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdClearDepthStencilImage<user_tag>(VkCommandBuffer commandBuffer,
+                                                                       VkImage image,
+                                                                       VkImageLayout imageLayout,
+                                                                       const VkClearDepthStencilValue* pDepthStencil,
+                                                                       uint32_t rangeCount,
+                                                                       const VkImageSubresourceRange* pRanges);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer srcBuffer,
-    VkBuffer dstBuffer,
-    uint32_t regionCount,
-    const VkBufferCopy* pRegions);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer<user_tag>(VkCommandBuffer commandBuffer,
+                                                           VkBuffer srcBuffer,
+                                                           VkBuffer dstBuffer,
+                                                           uint32_t regionCount,
+                                                           const VkBufferCopy* pRegions);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer2<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyBufferInfo2* pCopyBufferInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer2<user_tag>(VkCommandBuffer commandBuffer,
+                                                            const VkCopyBufferInfo2* pCopyBufferInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer2KHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyBufferInfo2* pCopyBufferInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer2KHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                               const VkCopyBufferInfo2* pCopyBufferInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBufferToImage<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer srcBuffer,
-    VkImage dstImage,
-    VkImageLayout dstImageLayout,
-    uint32_t regionCount,
-    const VkBufferImageCopy* pRegions);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBufferToImage<user_tag>(VkCommandBuffer commandBuffer,
+                                                                  VkBuffer srcBuffer,
+                                                                  VkImage dstImage,
+                                                                  VkImageLayout dstImageLayout,
+                                                                  uint32_t regionCount,
+                                                                  const VkBufferImageCopy* pRegions);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBufferToImage2<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL
+    layer_vkCmdCopyBufferToImage2<user_tag>(VkCommandBuffer commandBuffer,
+                                            const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBufferToImage2KHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL
+    layer_vkCmdCopyBufferToImage2KHR<user_tag>(VkCommandBuffer commandBuffer,
+                                               const VkCopyBufferToImageInfo2* pCopyBufferToImageInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkImage srcImage,
-    VkImageLayout srcImageLayout,
-    VkImage dstImage,
-    VkImageLayout dstImageLayout,
-    uint32_t regionCount,
-    const VkImageCopy* pRegions);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage<user_tag>(VkCommandBuffer commandBuffer,
+                                                          VkImage srcImage,
+                                                          VkImageLayout srcImageLayout,
+                                                          VkImage dstImage,
+                                                          VkImageLayout dstImageLayout,
+                                                          uint32_t regionCount,
+                                                          const VkImageCopy* pRegions);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage2<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyImageInfo2* pCopyImageInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage2<user_tag>(VkCommandBuffer commandBuffer,
+                                                           const VkCopyImageInfo2* pCopyImageInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage2KHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyImageInfo2* pCopyImageInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage2KHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                              const VkCopyImageInfo2* pCopyImageInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImageToBuffer<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkImage srcImage,
-    VkImageLayout srcImageLayout,
-    VkBuffer dstBuffer,
-    uint32_t regionCount,
-    const VkBufferImageCopy* pRegions);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImageToBuffer<user_tag>(VkCommandBuffer commandBuffer,
+                                                                  VkImage srcImage,
+                                                                  VkImageLayout srcImageLayout,
+                                                                  VkBuffer dstBuffer,
+                                                                  uint32_t regionCount,
+                                                                  const VkBufferImageCopy* pRegions);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImageToBuffer2<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL
+    layer_vkCmdCopyImageToBuffer2<user_tag>(VkCommandBuffer commandBuffer,
+                                            const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImageToBuffer2KHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo);
+template<>
+VKAPI_ATTR void VKAPI_CALL
+    layer_vkCmdCopyImageToBuffer2KHR<user_tag>(VkCommandBuffer commandBuffer,
+                                               const VkCopyImageToBufferInfo2* pCopyImageToBufferInfo);
 
 // Functions for debug
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDebugMarkerBeginEXT<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkDebugMarkerMarkerInfoEXT* pMarkerInfo);
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDebugMarkerBeginEXT<user_tag>(VkCommandBuffer commandBuffer,
+                                                                    const VkDebugMarkerMarkerInfoEXT* pMarkerInfo);
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDebugMarkerEndEXT<user_tag>(
-    VkCommandBuffer commandBuffer);
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDebugMarkerEndEXT<user_tag>(VkCommandBuffer commandBuffer);
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginDebugUtilsLabelEXT<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkDebugUtilsLabelEXT* pLabelInfo);
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginDebugUtilsLabelEXT<user_tag>(VkCommandBuffer commandBuffer,
+                                                                        const VkDebugUtilsLabelEXT* pLabelInfo);
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndDebugUtilsLabelEXT<user_tag>(
-    VkCommandBuffer commandBuffer);
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndDebugUtilsLabelEXT<user_tag>(VkCommandBuffer commandBuffer);
 
 // Functions for queues
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueuePresentKHR<user_tag>(
-    VkQueue queue,
-    const VkPresentInfoKHR* pPresentInfo);
+VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueuePresentKHR<user_tag>(VkQueue queue, const VkPresentInfoKHR* pPresentInfo);
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit<user_tag>(
-    VkQueue queue,
-    uint32_t submitCount,
-    const VkSubmitInfo* pSubmits,
-    VkFence fence);
+VKAPI_ATTR VkResult VKAPI_CALL
+    layer_vkQueueSubmit<user_tag>(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence);
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit2<user_tag>(
-    VkQueue queue,
-    uint32_t submitCount,
-    const VkSubmitInfo2* pSubmits,
-    VkFence fence);
+VKAPI_ATTR VkResult VKAPI_CALL
+    layer_vkQueueSubmit2<user_tag>(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence);
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit2KHR<user_tag>(
-    VkQueue queue,
-    uint32_t submitCount,
-    const VkSubmitInfo2* pSubmits,
-    VkFence fence);
+VKAPI_ATTR VkResult VKAPI_CALL layer_vkQueueSubmit2KHR<user_tag>(VkQueue queue,
+                                                                 uint32_t submitCount,
+                                                                 const VkSubmitInfo2* pSubmits,
+                                                                 VkFence fence);

--- a/layer_gpu_timeline/source/layer_device_functions_command_pool.cpp
+++ b/layer_gpu_timeline/source/layer_device_functions_command_pool.cpp
@@ -23,31 +23,29 @@
  * ----------------------------------------------------------------------------
  */
 
-#include <mutex>
-
 #include "device.hpp"
-#include "layer_device_functions.hpp"
+#include "framework/device_dispatch_table.hpp"
+
+#include <mutex>
 
 extern std::mutex g_vulkanLock;
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateCommandPool<user_tag>(
-    VkDevice device,
-    const VkCommandPoolCreateInfo* pCreateInfo,
-    const VkAllocationCallbacks* pAllocator,
-    VkCommandPool* pCommandPool
-) {
+template<>
+VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateCommandPool<user_tag>(VkDevice device,
+                                                                   const VkCommandPoolCreateInfo* pCreateInfo,
+                                                                   const VkAllocationCallbacks* pAllocator,
+                                                                   VkCommandPool* pCommandPool)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(device);
 
     // Release the lock to call into the driver
     lock.unlock();
-    VkResult result = layer->driver.vkCreateCommandPool(
-        device, pCreateInfo, pAllocator, pCommandPool);
+    VkResult result = layer->driver.vkCreateCommandPool(device, pCreateInfo, pAllocator, pCommandPool);
     if (result != VK_SUCCESS)
     {
         return result;
@@ -61,16 +59,15 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateCommandPool<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkResetCommandPool<user_tag>(
-    VkDevice device,
-    VkCommandPool commandPool,
-    VkCommandPoolResetFlags flags
-) {
+template<>
+VKAPI_ATTR VkResult VKAPI_CALL layer_vkResetCommandPool<user_tag>(VkDevice device,
+                                                                  VkCommandPool commandPool,
+                                                                  VkCommandPoolResetFlags flags)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(device);
 
     auto& tracker = layer->getStateTracker();
@@ -82,16 +79,15 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkResetCommandPool<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkDestroyCommandPool<user_tag>(
-    VkDevice device,
-    VkCommandPool commandPool,
-    const VkAllocationCallbacks* pAllocator
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkDestroyCommandPool<user_tag>(VkDevice device,
+                                                                VkCommandPool commandPool,
+                                                                const VkAllocationCallbacks* pAllocator)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(device);
 
     auto& tracker = layer->getStateTracker();

--- a/layer_gpu_timeline/source/layer_device_functions_debug.cpp
+++ b/layer_gpu_timeline/source/layer_device_functions_debug.cpp
@@ -23,23 +23,22 @@
  * ----------------------------------------------------------------------------
  */
 
-#include <mutex>
-
 #include "device.hpp"
-#include "layer_device_functions.hpp"
+#include "framework/device_dispatch_table.hpp"
+
+#include <mutex>
 
 extern std::mutex g_vulkanLock;
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDebugMarkerBeginEXT<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkDebugMarkerMarkerInfoEXT* pMarkerInfo
-) {
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDebugMarkerBeginEXT<user_tag>(VkCommandBuffer commandBuffer,
+                                                                    const VkDebugMarkerMarkerInfoEXT* pMarkerInfo)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     auto& tracker = layer->getStateTracker();
@@ -55,13 +54,12 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdDebugMarkerBeginEXT<user_tag>(
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDebugMarkerEndEXT<user_tag>(
-    VkCommandBuffer commandBuffer
-) {
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDebugMarkerEndEXT<user_tag>(VkCommandBuffer commandBuffer)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     auto& tracker = layer->getStateTracker();
@@ -77,14 +75,13 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdDebugMarkerEndEXT<user_tag>(
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginDebugUtilsLabelEXT<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkDebugUtilsLabelEXT* pLabelInfo
-) {
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginDebugUtilsLabelEXT<user_tag>(VkCommandBuffer commandBuffer,
+                                                                        const VkDebugUtilsLabelEXT* pLabelInfo)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     auto& tracker = layer->getStateTracker();
@@ -100,13 +97,12 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginDebugUtilsLabelEXT<user_tag>(
 
 /* See Vulkan API for documentation. */
 template<>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndDebugUtilsLabelEXT<user_tag>(
-    VkCommandBuffer commandBuffer
-) {
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndDebugUtilsLabelEXT<user_tag>(VkCommandBuffer commandBuffer)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     auto& tracker = layer->getStateTracker();

--- a/layer_gpu_timeline/source/layer_device_functions_dispatch.cpp
+++ b/layer_gpu_timeline/source/layer_device_functions_dispatch.cpp
@@ -23,11 +23,11 @@
  * ----------------------------------------------------------------------------
  */
 
-#include <mutex>
-
 #include "device.hpp"
 #include "device_utils.hpp"
-#include "layer_device_functions.hpp"
+#include "framework/device_dispatch_table.hpp"
+
+#include <mutex>
 
 extern std::mutex g_vulkanLock;
 
@@ -42,38 +42,35 @@ extern std::mutex g_vulkanLock;
  *
  * @return The assigned tagID for the workload.
  */
-static uint64_t registerDispatch(
-    Device* layer,
-    VkCommandBuffer commandBuffer,
-    int64_t groupX,
-    int64_t groupY,
-    int64_t groupZ
-) {
+static uint64_t registerDispatch(Device* layer,
+                                 VkCommandBuffer commandBuffer,
+                                 int64_t groupX,
+                                 int64_t groupY,
+                                 int64_t groupZ)
+{
     auto& tracker = layer->getStateTracker();
     auto& cb = tracker.getCommandBuffer(commandBuffer);
     return cb.dispatch(groupX, groupY, groupZ);
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatch<user_tag>(
-    VkCommandBuffer commandBuffer,
-    uint32_t groupCountX,
-    uint32_t groupCountY,
-    uint32_t groupCountZ
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatch<user_tag>(VkCommandBuffer commandBuffer,
+                                                         uint32_t groupCountX,
+                                                         uint32_t groupCountY,
+                                                         uint32_t groupCountZ)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
-    uint64_t tagID = registerDispatch(
-        layer,
-        commandBuffer,
-        static_cast<int64_t>(groupCountX),
-        static_cast<int64_t>(groupCountY),
-        static_cast<int64_t>(groupCountZ));
+    uint64_t tagID = registerDispatch(layer,
+                                      commandBuffer,
+                                      static_cast<int64_t>(groupCountX),
+                                      static_cast<int64_t>(groupCountY),
+                                      static_cast<int64_t>(groupCountZ));
 
     // Release the lock to call into the driver
     lock.unlock();
@@ -83,78 +80,75 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatch<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatchBase<user_tag>(
-    VkCommandBuffer commandBuffer,
-    uint32_t baseGroupX,
-    uint32_t baseGroupY,
-    uint32_t baseGroupZ,
-    uint32_t groupCountX,
-    uint32_t groupCountY,
-    uint32_t groupCountZ
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatchBase<user_tag>(VkCommandBuffer commandBuffer,
+                                                             uint32_t baseGroupX,
+                                                             uint32_t baseGroupY,
+                                                             uint32_t baseGroupZ,
+                                                             uint32_t groupCountX,
+                                                             uint32_t groupCountY,
+                                                             uint32_t groupCountZ)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
-    uint64_t tagID = registerDispatch(
-        layer,
-        commandBuffer,
-        static_cast<int64_t>(groupCountX),
-        static_cast<int64_t>(groupCountY),
-        static_cast<int64_t>(groupCountZ));
+    uint64_t tagID = registerDispatch(layer,
+                                      commandBuffer,
+                                      static_cast<int64_t>(groupCountX),
+                                      static_cast<int64_t>(groupCountY),
+                                      static_cast<int64_t>(groupCountZ));
 
     // Release the lock to call into the driver
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
-    layer->driver.vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
+    layer->driver
+        .vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
     layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatchBaseKHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    uint32_t baseGroupX,
-    uint32_t baseGroupY,
-    uint32_t baseGroupZ,
-    uint32_t groupCountX,
-    uint32_t groupCountY,
-    uint32_t groupCountZ
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatchBaseKHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                uint32_t baseGroupX,
+                                                                uint32_t baseGroupY,
+                                                                uint32_t baseGroupZ,
+                                                                uint32_t groupCountX,
+                                                                uint32_t groupCountY,
+                                                                uint32_t groupCountZ)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
-    uint64_t tagID = registerDispatch(
-        layer,
-        commandBuffer,
-        static_cast<int64_t>(groupCountX),
-        static_cast<int64_t>(groupCountY),
-        static_cast<int64_t>(groupCountZ));
+    uint64_t tagID = registerDispatch(layer,
+                                      commandBuffer,
+                                      static_cast<int64_t>(groupCountX),
+                                      static_cast<int64_t>(groupCountY),
+                                      static_cast<int64_t>(groupCountZ));
 
     // Release the lock to call into the driver
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
-    layer->driver.vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
+    layer->driver
+        .vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
     layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatchIndirect<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer buffer,
-    VkDeviceSize offset
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatchIndirect<user_tag>(VkCommandBuffer commandBuffer,
+                                                                 VkBuffer buffer,
+                                                                 VkDeviceSize offset)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     uint64_t tagID = registerDispatch(layer, commandBuffer, -1, -1, -1);

--- a/layer_gpu_timeline/source/layer_device_functions_draw_call.cpp
+++ b/layer_gpu_timeline/source/layer_device_functions_draw_call.cpp
@@ -23,12 +23,12 @@
  * ----------------------------------------------------------------------------
  */
 
+#include "device.hpp"
+#include "framework/device_dispatch_table.hpp"
+
 #include <memory>
 #include <mutex>
 #include <thread>
-
-#include "device.hpp"
-#include "layer_device_functions.hpp"
 
 extern std::mutex g_vulkanLock;
 
@@ -38,28 +38,25 @@ extern std::mutex g_vulkanLock;
  * @param layer           The layer context for the device.
  * @param commandBuffer   The command buffer we are recording.
  */
-static void registerDrawCall(
-    Device* layer,
-    VkCommandBuffer commandBuffer
-) {
+static void registerDrawCall(Device* layer, VkCommandBuffer commandBuffer)
+{
     auto& state = layer->getStateTracker();
     auto& stats = state.getCommandBuffer(commandBuffer).getStats();
     stats.incDrawCallCount();
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDraw<user_tag>(
-    VkCommandBuffer commandBuffer,
-    uint32_t vertexCount,
-    uint32_t instanceCount,
-    uint32_t firstVertex,
-    uint32_t firstInstance
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDraw<user_tag>(VkCommandBuffer commandBuffer,
+                                                     uint32_t vertexCount,
+                                                     uint32_t instanceCount,
+                                                     uint32_t firstVertex,
+                                                     uint32_t firstInstance)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     registerDrawCall(layer, commandBuffer);
@@ -70,19 +67,18 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdDraw<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndexed<user_tag>(
-    VkCommandBuffer commandBuffer,
-    uint32_t indexCount,
-    uint32_t instanceCount,
-    uint32_t firstIndex,
-    int32_t vertexOffset,
-    uint32_t firstInstance
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndexed<user_tag>(VkCommandBuffer commandBuffer,
+                                                            uint32_t indexCount,
+                                                            uint32_t instanceCount,
+                                                            uint32_t firstIndex,
+                                                            int32_t vertexOffset,
+                                                            uint32_t firstInstance)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     registerDrawCall(layer, commandBuffer);
@@ -93,18 +89,17 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndexed<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndexedIndirect<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer buffer,
-    VkDeviceSize offset,
-    uint32_t drawCount,
-    uint32_t stride
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndexedIndirect<user_tag>(VkCommandBuffer commandBuffer,
+                                                                    VkBuffer buffer,
+                                                                    VkDeviceSize offset,
+                                                                    uint32_t drawCount,
+                                                                    uint32_t stride)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     registerDrawCall(layer, commandBuffer);
@@ -115,66 +110,75 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndexedIndirect<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndexedIndirectCount<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer buffer,
-    VkDeviceSize offset,
-    VkBuffer countBuffer,
-    VkDeviceSize countBufferOffset,
-    uint32_t maxDrawCount,
-    uint32_t stride
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndexedIndirectCount<user_tag>(VkCommandBuffer commandBuffer,
+                                                                         VkBuffer buffer,
+                                                                         VkDeviceSize offset,
+                                                                         VkBuffer countBuffer,
+                                                                         VkDeviceSize countBufferOffset,
+                                                                         uint32_t maxDrawCount,
+                                                                         uint32_t stride)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     registerDrawCall(layer, commandBuffer);
 
     // Release the lock to call into the driver
     lock.unlock();
-    layer->driver.vkCmdDrawIndexedIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+    layer->driver.vkCmdDrawIndexedIndirectCount(commandBuffer,
+                                                buffer,
+                                                offset,
+                                                countBuffer,
+                                                countBufferOffset,
+                                                maxDrawCount,
+                                                stride);
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndexedIndirectCountKHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer buffer,
-    VkDeviceSize offset,
-    VkBuffer countBuffer,
-    VkDeviceSize countBufferOffset,
-    uint32_t maxDrawCount,
-    uint32_t stride
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndexedIndirectCountKHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                            VkBuffer buffer,
+                                                                            VkDeviceSize offset,
+                                                                            VkBuffer countBuffer,
+                                                                            VkDeviceSize countBufferOffset,
+                                                                            uint32_t maxDrawCount,
+                                                                            uint32_t stride)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     registerDrawCall(layer, commandBuffer);
 
     // Release the lock to call into the driver
     lock.unlock();
-    layer->driver.vkCmdDrawIndexedIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+    layer->driver.vkCmdDrawIndexedIndirectCountKHR(commandBuffer,
+                                                   buffer,
+                                                   offset,
+                                                   countBuffer,
+                                                   countBufferOffset,
+                                                   maxDrawCount,
+                                                   stride);
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndirect<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer buffer,
-    VkDeviceSize offset,
-    uint32_t drawCount,
-    uint32_t stride
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndirect<user_tag>(VkCommandBuffer commandBuffer,
+                                                             VkBuffer buffer,
+                                                             VkDeviceSize offset,
+                                                             uint32_t drawCount,
+                                                             uint32_t stride)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     registerDrawCall(layer, commandBuffer);
@@ -185,73 +189,78 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndirect<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndirectByteCountEXT<user_tag>(
-    VkCommandBuffer commandBuffer,
-    uint32_t instanceCount,
-    uint32_t firstInstance,
-    VkBuffer counterBuffer,
-    VkDeviceSize counterBufferOffset,
-    uint32_t counterOffset,
-    uint32_t vertexStride
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndirectByteCountEXT<user_tag>(VkCommandBuffer commandBuffer,
+                                                                         uint32_t instanceCount,
+                                                                         uint32_t firstInstance,
+                                                                         VkBuffer counterBuffer,
+                                                                         VkDeviceSize counterBufferOffset,
+                                                                         uint32_t counterOffset,
+                                                                         uint32_t vertexStride)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     registerDrawCall(layer, commandBuffer);
 
     // Release the lock to call into the driver
     lock.unlock();
-    layer->driver.vkCmdDrawIndirectByteCountEXT(commandBuffer, instanceCount, firstInstance, counterBuffer, counterBufferOffset, counterOffset, vertexStride);
+    layer->driver.vkCmdDrawIndirectByteCountEXT(commandBuffer,
+                                                instanceCount,
+                                                firstInstance,
+                                                counterBuffer,
+                                                counterBufferOffset,
+                                                counterOffset,
+                                                vertexStride);
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndirectCount<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer buffer,
-    VkDeviceSize offset,
-    VkBuffer countBuffer,
-    VkDeviceSize countBufferOffset,
-    uint32_t maxDrawCount,
-    uint32_t stride
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndirectCount<user_tag>(VkCommandBuffer commandBuffer,
+                                                                  VkBuffer buffer,
+                                                                  VkDeviceSize offset,
+                                                                  VkBuffer countBuffer,
+                                                                  VkDeviceSize countBufferOffset,
+                                                                  uint32_t maxDrawCount,
+                                                                  uint32_t stride)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     registerDrawCall(layer, commandBuffer);
 
     // Release the lock to call into the driver
     lock.unlock();
-    layer->driver.vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+    layer->driver
+        .vkCmdDrawIndirectCount(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndirectCountKHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    VkBuffer buffer,
-    VkDeviceSize offset,
-    VkBuffer countBuffer,
-    VkDeviceSize countBufferOffset,
-    uint32_t maxDrawCount,
-    uint32_t stride
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdDrawIndirectCountKHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                     VkBuffer buffer,
+                                                                     VkDeviceSize offset,
+                                                                     VkBuffer countBuffer,
+                                                                     VkDeviceSize countBufferOffset,
+                                                                     uint32_t maxDrawCount,
+                                                                     uint32_t stride)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     registerDrawCall(layer, commandBuffer);
 
     // Release the lock to call into the driver
     lock.unlock();
-    layer->driver.vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
+    layer->driver
+        .vkCmdDrawIndirectCountKHR(commandBuffer, buffer, offset, countBuffer, countBufferOffset, maxDrawCount, stride);
 }

--- a/layer_gpu_timeline/source/layer_device_functions_render_pass.cpp
+++ b/layer_gpu_timeline/source/layer_device_functions_render_pass.cpp
@@ -23,29 +23,27 @@
  * ----------------------------------------------------------------------------
  */
 
-#include <mutex>
-
+#include "device.hpp"
+#include "device_utils.hpp"
+#include "framework/device_dispatch_table.hpp"
 #include "framework/utils.hpp"
 #include "trackers/render_pass.hpp"
 
-#include "device.hpp"
-#include "device_utils.hpp"
-#include "layer_device_functions.hpp"
+#include <mutex>
 
 extern std::mutex g_vulkanLock;
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateRenderPass<user_tag>(
-    VkDevice device,
-    const VkRenderPassCreateInfo* pCreateInfo,
-    const VkAllocationCallbacks* pAllocator,
-    VkRenderPass* pRenderPass
-) {
+template<>
+VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateRenderPass<user_tag>(VkDevice device,
+                                                                  const VkRenderPassCreateInfo* pCreateInfo,
+                                                                  const VkAllocationCallbacks* pAllocator,
+                                                                  VkRenderPass* pRenderPass)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(device);
 
     // Release the lock to call into the driver
@@ -64,17 +62,16 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateRenderPass<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateRenderPass2<user_tag>(
-    VkDevice device,
-    const VkRenderPassCreateInfo2* pCreateInfo,
-    const VkAllocationCallbacks* pAllocator,
-    VkRenderPass* pRenderPass
-) {
+template<>
+VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateRenderPass2<user_tag>(VkDevice device,
+                                                                   const VkRenderPassCreateInfo2* pCreateInfo,
+                                                                   const VkAllocationCallbacks* pAllocator,
+                                                                   VkRenderPass* pRenderPass)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(device);
 
     // Release the lock to call into the driver
@@ -93,17 +90,16 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateRenderPass2<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateRenderPass2KHR<user_tag>(
-    VkDevice device,
-    const VkRenderPassCreateInfo2* pCreateInfo,
-    const VkAllocationCallbacks* pAllocator,
-    VkRenderPass* pRenderPass
-) {
+template<>
+VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateRenderPass2KHR<user_tag>(VkDevice device,
+                                                                      const VkRenderPassCreateInfo2* pCreateInfo,
+                                                                      const VkAllocationCallbacks* pAllocator,
+                                                                      VkRenderPass* pRenderPass)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(device);
 
     // Release the lock to call into the driver
@@ -122,16 +118,15 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateRenderPass2KHR<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkDestroyRenderPass<user_tag>(
-    VkDevice device,
-    VkRenderPass renderPass,
-    const VkAllocationCallbacks* pAllocator
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkDestroyRenderPass<user_tag>(VkDevice device,
+                                                               VkRenderPass renderPass,
+                                                               const VkAllocationCallbacks* pAllocator)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(device);
 
     auto& tracker = layer->getStateTracker();
@@ -143,16 +138,15 @@ VKAPI_ATTR void VKAPI_CALL layer_vkDestroyRenderPass<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderPassBeginInfo* pRenderPassBegin,
-    VkSubpassContents contents
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass<user_tag>(VkCommandBuffer commandBuffer,
+                                                                const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                                VkSubpassContents contents)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     auto& tracker = layer->getStateTracker();
@@ -172,16 +166,15 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderPassBeginInfo* pRenderPassBegin,
-    const VkSubpassBeginInfo* pSubpassBeginInfo
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2<user_tag>(VkCommandBuffer commandBuffer,
+                                                                 const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                                 const VkSubpassBeginInfo* pSubpassBeginInfo)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     auto& tracker = layer->getStateTracker();
@@ -201,16 +194,15 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2KHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderPassBeginInfo* pRenderPassBegin,
-    const VkSubpassBeginInfo* pSubpassBeginInfo
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2KHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                    const VkRenderPassBeginInfo* pRenderPassBegin,
+                                                                    const VkSubpassBeginInfo* pSubpassBeginInfo)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     auto& tracker = layer->getStateTracker();
@@ -230,15 +222,14 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderPass2KHR<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRendering<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderingInfo* pRenderingInfo
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRendering<user_tag>(VkCommandBuffer commandBuffer,
+                                                               const VkRenderingInfo* pRenderingInfo)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     auto& tracker = layer->getStateTracker();
@@ -253,8 +244,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRendering<user_tag>(
     uint32_t height = pRenderingInfo->renderArea.extent.height;
 
     // Notify the command buffer we are starting a new render pass
-    uint64_t tagID = cb.renderPassBegin(
-        rp, width, height, resuming, suspending);
+    uint64_t tagID = cb.renderPassBegin(rp, width, height, resuming, suspending);
 
     // Release the lock to call into the driver
     lock.unlock();
@@ -267,15 +257,14 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRendering<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderingKHR<user_tag>(
-    VkCommandBuffer commandBuffer,
-    const VkRenderingInfo* pRenderingInfo
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderingKHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                  const VkRenderingInfo* pRenderingInfo)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     auto& tracker = layer->getStateTracker();
@@ -290,8 +279,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderingKHR<user_tag>(
     uint32_t height = pRenderingInfo->renderArea.extent.height;
 
     // Notify the command buffer we are starting a new render pass
-    uint64_t tagID = cb.renderPassBegin(
-        rp, width, height, resuming, suspending);
+    uint64_t tagID = cb.renderPassBegin(rp, width, height, resuming, suspending);
 
     // Release the lock to call into the driver
     lock.unlock();
@@ -304,14 +292,13 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdBeginRenderingKHR<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderPass<user_tag>(
-    VkCommandBuffer commandBuffer
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderPass<user_tag>(VkCommandBuffer commandBuffer)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Update the layer command stream in the tracker
@@ -326,14 +313,13 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderPass<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL  layer_vkCmdEndRendering<user_tag>(
-    VkCommandBuffer commandBuffer
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRendering<user_tag>(VkCommandBuffer commandBuffer)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Update the layer command stream in the tracker
@@ -351,14 +337,13 @@ VKAPI_ATTR void VKAPI_CALL  layer_vkCmdEndRendering<user_tag>(
 }
 
 /* See Vulkan API for documentation. */
-template <>
-VKAPI_ATTR void VKAPI_CALL  layer_vkCmdEndRenderingKHR<user_tag>(
-    VkCommandBuffer commandBuffer
-) {
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderingKHR<user_tag>(VkCommandBuffer commandBuffer)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(commandBuffer);
 
     // Update the layer command stream in the tracker

--- a/layer_gpu_timeline/source/timeline_comms.cpp
+++ b/layer_gpu_timeline/source/timeline_comms.cpp
@@ -23,15 +23,13 @@
  * ----------------------------------------------------------------------------
  */
 
-#include <memory>
-
 #include "timeline_comms.hpp"
 
+#include <memory>
+
 /* See header for documentation. */
-TimelineComms::TimelineComms(
-    Comms::CommsInterface& _comms
-):
-    comms(_comms)
+TimelineComms::TimelineComms(Comms::CommsInterface& _comms)
+    : comms(_comms)
 {
     if (comms.isConnected())
     {
@@ -40,8 +38,7 @@ TimelineComms::TimelineComms(
 }
 
 /* See header for documentation. */
-void TimelineComms::txMessage(
-    const std::string& message)
+void TimelineComms::txMessage(const std::string& message)
 {
     // Message endpoint is not available
     if (endpoint == 0)

--- a/layer_gpu_timeline/source/timeline_comms.hpp
+++ b/layer_gpu_timeline/source/timeline_comms.hpp
@@ -47,22 +47,20 @@ public:
      *
      * @param comms   The common comms module used by all services.
      */
-    TimelineComms(
-        Comms::CommsInterface& comms);
+    TimelineComms(Comms::CommsInterface& comms);
 
     /**
      * @brief Send a message to the GPU timeline endpoint service.
      *
      * @param message   The message to send.
      */
-    void txMessage(
-        const std::string& message);
+    void txMessage(const std::string& message);
 
 private:
     /**
      * @brief The endpoint ID of the service, or 0 if not found.
      */
-    Comms::EndpointID endpoint { 0 };
+    Comms::EndpointID endpoint {0};
 
     /**
      * @brief The common module for network messaging.

--- a/source_common/CMakeLists.txt
+++ b/source_common/CMakeLists.txt
@@ -25,5 +25,7 @@
 # depends on per-layer implementations of the root intercept Instance and
 # Device classes which get specialized for each use case.
 
+include(../cmake/clang-tools.cmake)
+
 add_subdirectory(comms)
 add_subdirectory(trackers)

--- a/source_common/comms/CMakeLists.txt
+++ b/source_common/comms/CMakeLists.txt
@@ -40,3 +40,5 @@ lgl_set_build_options(${LIB_BINARY})
 if(${LGL_UNITTEST})
     add_subdirectory(test)
 endif()
+
+add_clang_tools()

--- a/source_common/comms/comms_interface.hpp
+++ b/source_common/comms/comms_interface.hpp
@@ -55,7 +55,7 @@ using MessageData = std::vector<uint8_t>;
  * Note that this hides the built-in registry service, which uses endpoint
  * zero, because a normaluser should not be calling it.
  */
-static const EndpointID NO_ENDPOINT { 0 };
+static const EndpointID NO_ENDPOINT {0};
 
 /**
  * @brief Abstract base class defining the public interface for comms.
@@ -79,8 +79,7 @@ public:
      *
      * @return The service address, or @c NO_ENDPOINT if service is not found.
      */
-    virtual EndpointID getEndpointID(
-        const std::string& name) = 0;
+    virtual EndpointID getEndpointID(const std::string& name) = 0;
 
     /**
      * @brief Asynchronously transmit message to the host.
@@ -91,9 +90,7 @@ public:
      * @param endpoint   The address of the destination service.
      * @param data       The data to transmit.
      */
-    virtual void txAsync(
-        EndpointID endpoint,
-        std::unique_ptr<MessageData> data) = 0;
+    virtual void txAsync(EndpointID endpoint, std::unique_ptr<MessageData> data) = 0;
 
     /**
      * @brief Synchronously transmit message to the host.
@@ -105,9 +102,7 @@ public:
      * @param endpoint   The address of the destination service.
      * @param data       The data to transmit.
      */
-    virtual void tx(
-        EndpointID endpoint,
-        std::unique_ptr<MessageData> data) = 0;
+    virtual void tx(EndpointID endpoint, std::unique_ptr<MessageData> data) = 0;
 
     /**
      * @brief Synchronously transmit message to the host and wait for response.
@@ -122,9 +117,7 @@ public:
      *
      * @return The response message data payload.
      */
-    virtual std::unique_ptr<MessageData> txRx(
-        EndpointID endpoint,
-        std::unique_ptr<MessageData> data) = 0;
+    virtual std::unique_ptr<MessageData> txRx(EndpointID endpoint, std::unique_ptr<MessageData> data) = 0;
 };
 
 }

--- a/source_common/comms/comms_message.cpp
+++ b/source_common/comms/comms_message.cpp
@@ -33,18 +33,15 @@
 namespace Comms
 {
 
-Message::Message(
-    EndpointID _endpointID,
-    MessageType _messageType,
-    MessageID _messageID,
-    std::unique_ptr<MessageData> _transmitData
-) :
-    endpointID(_endpointID),
-    messageType(_messageType),
-    messageID(_messageID),
-    transmitData(std::move(_transmitData))
+Message::Message(EndpointID _endpointID,
+                 MessageType _messageType,
+                 MessageID _messageID,
+                 std::unique_ptr<MessageData> _transmitData)
+    : endpointID(_endpointID),
+      messageType(_messageType),
+      messageID(_messageID),
+      transmitData(std::move(_transmitData))
 {
-
 }
 
 }

--- a/source_common/comms/comms_message.hpp
+++ b/source_common/comms/comms_message.hpp
@@ -29,8 +29,8 @@
  */
 #pragma once
 
-#include "comms/comms_interface.hpp"
 #include "../utils/queue.hpp"
+#include "comms/comms_interface.hpp"
 
 namespace Comms
 {
@@ -43,7 +43,8 @@ using MessageID = uint64_t;
 /**
  * @brief A type used for message types in the protocol.
  */
-enum class MessageType: uint8_t {
+enum class MessageType : uint8_t
+{
     /** Message is an asynchronous transmit. */
     TX_ASYNC = 0,
     /** Message is a synchronous transmit. */
@@ -59,16 +60,16 @@ enum class MessageType: uint8_t {
  */
 typedef struct __attribute__((packed))
 {
-    uint8_t  messageType;  // Is this tx_async (0), tx (1), or tx_rx (2)?
-    uint8_t  endpointID;   // The endpoint service address.
-    uint64_t messageID;    // The unique message ID for a tx_rx pair.
-    uint32_t payloadSize;  // The size of the payload in bytes.
+    uint8_t messageType;  // Is this tx_async (0), tx (1), or tx_rx (2)?
+    uint8_t endpointID;   // The endpoint service address.
+    uint64_t messageID;   // The unique message ID for a tx_rx pair.
+    uint32_t payloadSize; // The size of the payload in bytes.
 } MessageHeader;
 
 /**
  * @brief Class representing a task in the protocol.
  */
-class Message: public Task
+class Message : public Task
 {
 public:
     /**
@@ -79,11 +80,10 @@ public:
      * @param messageID      The sequence ID of the message.
      * @param transmitData   The data to transmit.
      */
-    Message(
-        EndpointID endpointID,
-        MessageType messageType,
-        MessageID messageID,
-        std::unique_ptr<MessageData> transmitData);
+    Message(EndpointID endpointID,
+            MessageType messageType,
+            MessageID messageID,
+            std::unique_ptr<MessageData> transmitData);
 
     /**
      * @brief The type of the message.

--- a/source_common/comms/comms_module.hpp
+++ b/source_common/comms/comms_module.hpp
@@ -77,8 +77,8 @@
 
 #include "comms/comms_interface.hpp"
 #include "comms/comms_message.hpp"
-#include "comms/comms_transmitter.hpp"
 #include "comms/comms_receiver.hpp"
+#include "comms/comms_transmitter.hpp"
 #include "utils/queue.hpp"
 
 namespace Comms
@@ -89,7 +89,7 @@ namespace Comms
  *
  * Exposes the CommsInterface to calling code.
  */
-class CommsModule: public CommsInterface
+class CommsModule : public CommsInterface
 {
 public:
     /**
@@ -101,8 +101,7 @@ public:
      *
      * @param domainAddress   The unix domain address to use.
      */
-    CommsModule(
-        const std::string& domainAddress);
+    CommsModule(const std::string& domainAddress);
 
     /**
      * @brief Construct a new instance using a TCP/IP socket.
@@ -110,9 +109,7 @@ public:
      * @param hostAddress   The host name or IP address to use.
      * @param port          The port number to use.
      */
-    CommsModule(
-        const std::string& hostAddress,
-        int port);
+    CommsModule(const std::string& hostAddress, int port);
 
     /**
      * @brief Close the host connection and stop all worker threads.
@@ -127,23 +124,16 @@ public:
     virtual bool isConnected();
 
     /** See @c comms_interface.hpp for documentation. */
-    virtual EndpointID getEndpointID(
-        const std::string& name);
+    virtual EndpointID getEndpointID(const std::string& name);
 
     /** See @c comms_interface.hpp for documentation. */
-    virtual void txAsync(
-        EndpointID endpoint,
-        std::unique_ptr<MessageData> data);
+    virtual void txAsync(EndpointID endpoint, std::unique_ptr<MessageData> data);
 
     /** See @c comms_interface.hpp for documentation. */
-    virtual void tx(
-        EndpointID endpoint,
-        std::unique_ptr<MessageData> data);
+    virtual void tx(EndpointID endpoint, std::unique_ptr<MessageData> data);
 
     /** See @c comms_interface.hpp for documentation. */
-    virtual std::unique_ptr<MessageData> txRx(
-        EndpointID endpoint,
-        std::unique_ptr<MessageData> data);
+    virtual std::unique_ptr<MessageData> txRx(EndpointID endpoint, std::unique_ptr<MessageData> data);
 
     // Allow module internal classes to access private members
     friend class Transmitter;
@@ -162,8 +152,7 @@ private:
      *
      * @param message   The message to queue.
      */
-    void enqueueMessage(
-        std::shared_ptr<Message> message);
+    void enqueueMessage(std::shared_ptr<Message> message);
 
     /**
      * @brief Get the oldest message from the outbound message task queue.
@@ -176,12 +165,12 @@ private:
     /**
      * @brief The socket for communications.
      */
-    int sockfd { -1 };
+    int sockfd {-1};
 
     /**
      * @brief The next message ID nonce to use.
      */
-    std::atomic<MessageID> nextMessageID { 1 };
+    std::atomic<MessageID> nextMessageID {1};
 
     /**
      * @brief The FIFO queue of messages to send.

--- a/source_common/comms/comms_receiver.cpp
+++ b/source_common/comms/comms_receiver.cpp
@@ -28,24 +28,24 @@
  * The implementation of the communications module receiver worker.
  */
 
-#include <cinttypes>
-#include <iostream>
-#include <sys/socket.h>
-#include <unistd.h>
-#include <unordered_map>
-
 #include "comms/comms_receiver.hpp"
+
 #include "comms/comms_module.hpp"
 #include "framework/utils.hpp"
 #include "utils/misc.hpp"
 
+#include <cinttypes>
+#include <iostream>
+#include <unordered_map>
+
+#include <sys/socket.h>
+#include <unistd.h>
+
 namespace Comms
 {
 /* See header for documentation. */
-Receiver::Receiver(
-    CommsModule& _parent
-) :
-    parent(_parent)
+Receiver::Receiver(CommsModule& _parent)
+    : parent(_parent)
 {
     int pipe_err = pipe(stopRequestPipe);
     if (pipe_err)
@@ -87,11 +87,10 @@ void Receiver::stop()
 }
 
 /* See header for documentation. */
-void Receiver::parkMessage(
-    std::shared_ptr<Message> message
-) {
+void Receiver::parkMessage(std::shared_ptr<Message> message)
+{
     std::lock_guard<std::mutex> lock(parkingLock);
-    parkingBuffer.insert({ message->messageID, std::move(message) });
+    parkingBuffer.insert({message->messageID, std::move(message)});
 }
 
 /* See header for documentation. */
@@ -123,10 +122,8 @@ void Receiver::runReceiver()
 }
 
 /* See header for documentation. */
-void Receiver::wakeMessage(
-    MessageID messageID,
-    std::unique_ptr<MessageData> data
-) {
+void Receiver::wakeMessage(MessageID messageID, std::unique_ptr<MessageData> data)
+{
     std::lock_guard<std::mutex> lock(parkingLock);
 
     // Handle message not found ...
@@ -146,10 +143,8 @@ void Receiver::wakeMessage(
 }
 
 /* See header for documentation. */
-bool Receiver::receiveData(
-    uint8_t* data,
-    size_t dataSize
-) {
+bool Receiver::receiveData(uint8_t* data, size_t dataSize)
+{
     int sockfd = parent.sockfd;
     int pipefd = stopRequestPipe[0];
     int maxfd = std::max(sockfd, pipefd);

--- a/source_common/comms/comms_receiver.hpp
+++ b/source_common/comms/comms_receiver.hpp
@@ -29,11 +29,11 @@
  */
 #pragma once
 
+#include "comms/comms_message.hpp"
+
 #include <memory>
 #include <thread>
 #include <unordered_map>
-
-#include "comms/comms_message.hpp"
 
 namespace Comms
 {
@@ -52,8 +52,7 @@ public:
      *
      * @param parent   The parent comms module.
      */
-    Receiver(
-        CommsModule& parent);
+    Receiver(CommsModule& parent);
 
     /**
      * @brief Destroy this receiver.
@@ -72,8 +71,7 @@ public:
      *
      * @param message   The message waiting for a response.
      */
-    void parkMessage(
-        std::shared_ptr<Message> message);
+    void parkMessage(std::shared_ptr<Message> message);
 
 private:
     /**
@@ -87,9 +85,7 @@ private:
      * @param messageID   The message to wake.
      * @param data        The response data payload from the host.
      */
-    void wakeMessage(
-        MessageID messageID,
-        std::unique_ptr<MessageData> data);
+    void wakeMessage(MessageID messageID, std::unique_ptr<MessageData> data);
 
     /**
      * @brief Receive N bytes of data from the socket.
@@ -99,9 +95,7 @@ private:
      *
      * @return @c true if we received a message, @c false otherwise.
      */
-    bool receiveData(
-        uint8_t* data,
-        size_t dataSize);
+    bool receiveData(uint8_t* data, size_t dataSize);
 
 private:
     /**

--- a/source_common/comms/comms_transmitter.cpp
+++ b/source_common/comms/comms_transmitter.cpp
@@ -27,21 +27,21 @@
  * @file
  * The implementation of the communications module transmitter worker.
  */
-#include <iostream>
-#include <sys/socket.h>
-
 #include "comms/comms_transmitter.hpp"
+
 #include "comms/comms_module.hpp"
 #include "framework/utils.hpp"
+
+#include <iostream>
+
+#include <sys/socket.h>
 
 namespace Comms
 {
 
 /* See header for documentation. */
-Transmitter::Transmitter(
-    CommsModule& _parent
-) :
-    parent(_parent)
+Transmitter::Transmitter(CommsModule& _parent)
+    : parent(_parent)
 {
     // Create and start a worker thread
     worker = std::thread(&Transmitter::runTransmitter, this);
@@ -96,8 +96,7 @@ void Transmitter::stop()
 
     // Use a dummy message to wake worker thread if blocked on the queue
     auto stopData = std::make_unique<MessageData>();
-    auto message = std::make_shared<Message>(
-        0, MessageType::STOP, 0, std::move(stopData));
+    auto message = std::make_shared<Message>(0, MessageType::STOP, 0, std::move(stopData));
     parent.enqueueMessage(message);
 
     // Join on the worker thread
@@ -105,9 +104,8 @@ void Transmitter::stop()
 }
 
 /* See header for documentation. */
-void Transmitter::sendMessage(
-    const Message& message
-) {
+void Transmitter::sendMessage(const Message& message)
+{
     uint8_t* data = message.transmitData->data();
     size_t dataSize = message.transmitData->size();
 
@@ -126,11 +124,9 @@ void Transmitter::sendMessage(
 }
 
 /* See header for documentation. */
-void Transmitter::sendData(
-    uint8_t* data,
-    size_t dataSize
-) {
-    while(dataSize)
+void Transmitter::sendData(uint8_t* data, size_t dataSize)
+{
+    while (dataSize)
     {
         ssize_t sentSize = send(parent.sockfd, data, dataSize, 0);
         // An error occurred or server disconnected

--- a/source_common/comms/comms_transmitter.hpp
+++ b/source_common/comms/comms_transmitter.hpp
@@ -29,11 +29,11 @@
  */
 #pragma once
 
+#include "comms/comms_message.hpp"
+
 #include <atomic>
 #include <memory>
 #include <thread>
-
-#include "comms/comms_message.hpp"
 
 namespace Comms
 {
@@ -52,8 +52,7 @@ public:
      *
      * @param parent   The parent comms module.
      */
-    Transmitter(
-        CommsModule& parent);
+    Transmitter(CommsModule& parent);
 
     /**
      * @brief Destroy this transmitter.
@@ -78,8 +77,7 @@ private:
      *
      * @param message   The message to send.
      */
-    void sendMessage(
-        const Message& message);
+    void sendMessage(const Message& message);
 
     /**
      * @brief Send N bytes of data to the socket.
@@ -87,9 +85,7 @@ private:
      * @param data       The data to send.
      * @param dataSize   The number of bytes in the data.
      */
-    void sendData(
-        uint8_t* data,
-        size_t dataSize);
+    void sendData(uint8_t* data, size_t dataSize);
 
 private:
     /**

--- a/source_common/comms/test/CMakeLists.txt
+++ b/source_common/comms/test/CMakeLists.txt
@@ -76,3 +76,4 @@ install(
     TARGETS ${TEST_BINARY}
     DESTINATION bin)
 
+add_clang_tools()

--- a/source_common/comms/test/comms_test_server.cpp
+++ b/source_common/comms/test/comms_test_server.cpp
@@ -30,9 +30,10 @@
 
 #include "comms/test/comms_test_server.hpp"
 
-#include <arpa/inet.h>
 #include <cstring>
 #include <iostream>
+
+#include <arpa/inet.h>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <unistd.h>
@@ -41,9 +42,8 @@ namespace CommsTest
 {
 
 /* See header for documentation. */
-CommsTestServer::CommsTestServer(
-    const std::string& domainAddress
-) {
+CommsTestServer::CommsTestServer(const std::string& domainAddress)
+{
     int pipeErr = pipe(stopRequestPipe);
     if (pipeErr)
     {
@@ -59,7 +59,9 @@ CommsTestServer::CommsTestServer(
     }
 
     // Build the address to listen on
-    struct sockaddr_un servAddr {};
+    struct sockaddr_un servAddr
+    {
+    };
     servAddr.sun_family = AF_UNIX;
 
     // Copy the domain address, inserting leading NUL needed for abstract UDS
@@ -67,10 +69,9 @@ CommsTestServer::CommsTestServer(
     servAddr.sun_path[0] = '\0';
 
     // Bind the socket to the address
-    int bindErr = bind(
-        listenSockfd,
-        reinterpret_cast<const struct sockaddr*>(&servAddr),
-        offsetof(struct sockaddr_un, sun_path) + domainAddress.size() + 1);
+    int bindErr = bind(listenSockfd,
+                       reinterpret_cast<const struct sockaddr*>(&servAddr),
+                       offsetof(struct sockaddr_un, sun_path) + domainAddress.size() + 1);
     if (bindErr)
     {
         std::cout << "  - ERROR: Svr socket bind failed" << std::endl;
@@ -80,8 +81,8 @@ CommsTestServer::CommsTestServer(
     }
 
     // Listen on the socket
-    int listenErr = listen(listenSockfd,  5);
-    if(listenErr)
+    int listenErr = listen(listenSockfd, 5);
+    if (listenErr)
     {
         std::cout << "  - ERROR: Svr socket listen failed" << std::endl;
         close(listenSockfd);
@@ -95,9 +96,8 @@ CommsTestServer::CommsTestServer(
 }
 
 /* See header for documentation. */
-CommsTestServer::CommsTestServer(
-    int port
-) {
+CommsTestServer::CommsTestServer(int port)
+{
     int pipeErr = pipe(stopRequestPipe);
     if (pipeErr)
     {
@@ -119,16 +119,15 @@ CommsTestServer::CommsTestServer(
         std::cout << "  - WARN: Svr socket setsockopt failed" << std::endl;
     }
 
-    struct sockaddr_in servAddr {};
+    struct sockaddr_in servAddr
+    {
+    };
     servAddr.sin_family = AF_INET;
     servAddr.sin_port = htons(port);
     servAddr.sin_addr.s_addr = INADDR_ANY;
 
     // Bind the socket to the address
-    int bindErr = bind(
-        listenSockfd,
-        reinterpret_cast<const struct sockaddr*>(&servAddr),
-        sizeof(struct sockaddr_in));
+    int bindErr = bind(listenSockfd, reinterpret_cast<const struct sockaddr*>(&servAddr), sizeof(struct sockaddr_in));
     if (bindErr)
     {
         std::cout << "  - ERROR: Svr socket bind failed " << std::endl;
@@ -138,8 +137,8 @@ CommsTestServer::CommsTestServer(
     }
 
     // Listen on the socket
-    int listenErr = listen(listenSockfd,  5);
-    if(listenErr)
+    int listenErr = listen(listenSockfd, 5);
+    if (listenErr)
     {
         std::cout << "  - ERROR: Svr socket listen failed" << std::endl;
         close(listenSockfd);
@@ -190,7 +189,7 @@ void CommsTestServer::stop()
 void CommsTestServer::runServer()
 {
     int dataSockfd = accept(listenSockfd, NULL, NULL);
-    if(dataSockfd < 0)
+    if (dataSockfd < 0)
     {
         std::cout << "  - ERROR: Svr socket accept failed" << std::endl;
         close(listenSockfd);
@@ -220,10 +219,9 @@ void CommsTestServer::runServer()
 
         // Store the message for later checking
         std::string decodedPayload(payload->begin(), payload->end());
-        received.emplace_back(
-            static_cast<Comms::EndpointID>(header.endpointID),
-            static_cast<Comms::MessageType>(header.messageType),
-            std::move(payload));
+        received.emplace_back(static_cast<Comms::EndpointID>(header.endpointID),
+                              static_cast<Comms::MessageType>(header.messageType),
+                              std::move(payload));
 
         // If this is a tx_rx message reverse payload and send it back ...
         if (header.messageType == static_cast<uint8_t>(Comms::MessageType::TX_RX))
@@ -252,11 +250,8 @@ void CommsTestServer::runServer()
 }
 
 /* See header for documentation. */
-bool CommsTestServer::receiveData(
-    int sockfd,
-    uint8_t* data,
-    size_t dataSize
-) {
+bool CommsTestServer::receiveData(int sockfd, uint8_t* data, size_t dataSize)
+{
     int pipefd = stopRequestPipe[0];
     int maxfd = std::max(sockfd, pipefd);
 
@@ -298,12 +293,9 @@ bool CommsTestServer::receiveData(
 }
 
 /* See header for documentation. */
-void CommsTestServer::send_data(
-    int sockfd,
-    uint8_t* data,
-    size_t dataSize
-) {
-    while(dataSize)
+void CommsTestServer::send_data(int sockfd, uint8_t* data, size_t dataSize)
+{
+    while (dataSize)
     {
         ssize_t sentSize = send(sockfd, data, dataSize, 0);
         // An error occurred

--- a/source_common/comms/test/comms_test_server.hpp
+++ b/source_common/comms/test/comms_test_server.hpp
@@ -30,11 +30,11 @@
 
 #pragma once
 
+#include "comms/comms_message.hpp"
+
 #include <atomic>
 #include <string>
 #include <thread>
-
-#include "comms/comms_message.hpp"
 
 namespace CommsTest
 {
@@ -52,13 +52,12 @@ public:
      * @param messageType    The type of the message.
      * @param data            The received data.
      */
-    TestMessage(
-        Comms::EndpointID endpointID,
-        Comms::MessageType messageType,
-        std::unique_ptr<Comms::MessageData> data) :
-        endpointID(endpointID),
-        messageType(messageType),
-        data(std::move(data)) { }
+    TestMessage(Comms::EndpointID endpointID, Comms::MessageType messageType, std::unique_ptr<Comms::MessageData> data)
+        : endpointID(endpointID),
+          messageType(messageType),
+          data(std::move(data))
+    {
+    }
 
     /**
      * @brief The endpoint of the message.
@@ -76,7 +75,6 @@ public:
     std::unique_ptr<Comms::MessageData> data;
 };
 
-
 class CommsTestServer
 {
 public:
@@ -88,16 +86,14 @@ public:
      *
      * @param domainAddress   The unix domain address to use.
      */
-    CommsTestServer(
-        const std::string& domainAddress);
+    CommsTestServer(const std::string& domainAddress);
 
     /**
      * @brief Construct a new server listening on TCP/IP socket.
      *
      * @param port   The port number to use.
      */
-    CommsTestServer(
-        int port);
+    CommsTestServer(int port);
 
     /**
      * @brief Close the host connection and stop all worker threads.
@@ -128,10 +124,7 @@ private:
      *
      * @return @c true if we received a message, @c false otherwise.
      */
-    bool receiveData(
-        int sockfd,
-        uint8_t* data,
-        size_t dataSize);
+    bool receiveData(int sockfd, uint8_t* data, size_t dataSize);
 
     /**
      * @brief Send N bytes of data to the socket.
@@ -140,10 +133,7 @@ private:
      * @param data       The data to send.
      * @param dataSize   The number of bytes in the data.
      */
-    void send_data(
-        int sockfd,
-        uint8_t* data,
-        size_t dataSize);
+    void send_data(int sockfd, uint8_t* data, size_t dataSize);
 
 public:
     /**
@@ -155,7 +145,7 @@ private:
     /**
      * @brief The socket for listening for connections.
      */
-    int listenSockfd { -1 };
+    int listenSockfd {-1};
 
     /**
      * @brief Pipe used to unblock the read socket rather than use timeouts.

--- a/source_common/comms/test/unittest_comms.cpp
+++ b/source_common/comms/test/unittest_comms.cpp
@@ -32,31 +32,28 @@
  * A normal tx message guarantees that the messages is sent before returning,
  * but does not guarantee that the server has received and processed it.
  */
-#include <gtest/gtest.h>
-
 #include "comms/comms_interface.hpp"
 #include "comms/comms_module.hpp"
 #include "comms/test/comms_test_server.hpp"
 
+#include <gtest/gtest.h>
+
 using namespace CommsTest;
 
-std::unique_ptr<Comms::MessageData> makeTestPayload(
-    const std::string& str
-) {
+std::unique_ptr<Comms::MessageData> makeTestPayload(const std::string& str)
+{
     auto data = std::make_unique<Comms::MessageData>(str.begin(), str.end());
     return data;
 }
 
-std::string decodeTestPayload(
-    std::unique_ptr<Comms::MessageData> data
-) {
+std::string decodeTestPayload(std::unique_ptr<Comms::MessageData> data)
+{
     std::string str(data->begin(), data->end());
     return str;
 }
 
-std::string decodeTestPayload(
-    TestMessage& msg
-) {
+std::string decodeTestPayload(TestMessage& msg)
+{
     std::string str(msg.data->begin(), msg.data->end());
     return str;
 }
@@ -111,7 +108,7 @@ TEST(Comms, test_uds_tx_nb)
 
     EXPECT_EQ(server.received[0].endpointID, 2);
     EXPECT_EQ(server.received[0].data->size(), 4);
-    EXPECT_EQ(decodeTestPayload(server.received[0]),"abcd");
+    EXPECT_EQ(decodeTestPayload(server.received[0]), "abcd");
 }
 
 /** @brief Test lifecycle with a TX_ASYNC sent message. */
@@ -136,7 +133,7 @@ TEST(Comms, test_uds_tx_async_0b)
 
     EXPECT_EQ(server.received[1].endpointID, 2);
     EXPECT_EQ(server.received[1].data->size(), 4);
-    EXPECT_EQ(decodeTestPayload(server.received[1]),"abcd");
+    EXPECT_EQ(decodeTestPayload(server.received[1]), "abcd");
 }
 
 /** @brief Test lifecycle with a TX_ASYNC sent message. */
@@ -158,11 +155,11 @@ TEST(Comms, test_uds_tx_async_nb)
 
     EXPECT_EQ(server.received[0].endpointID, 1);
     EXPECT_EQ(server.received[0].data->size(), 4);
-    EXPECT_EQ(decodeTestPayload(server.received[0]),"abcd");
+    EXPECT_EQ(decodeTestPayload(server.received[0]), "abcd");
 
     EXPECT_EQ(server.received[1].endpointID, 2);
     EXPECT_EQ(server.received[1].data->size(), 3);
-    EXPECT_EQ(decodeTestPayload(server.received[1]),"efg");
+    EXPECT_EQ(decodeTestPayload(server.received[1]), "efg");
 }
 
 /** @brief Test lifecycle with a TX_RX sent message. */
@@ -202,11 +199,11 @@ TEST(Comms, test_uds_tx_rx_nb)
 
     EXPECT_EQ(server.received[0].endpointID, 1);
     EXPECT_EQ(server.received[0].data->size(), 4);
-    EXPECT_EQ(decodeTestPayload(server.received[0]),"abcd");
+    EXPECT_EQ(decodeTestPayload(server.received[0]), "abcd");
 
     // Validate it was responded to correctly
     EXPECT_EQ(resps.size(), 4);
-    EXPECT_EQ(resps,"dcba");
+    EXPECT_EQ(resps, "dcba");
 }
 
 // ----------------------------------------------------------------------------
@@ -258,7 +255,7 @@ TEST(Comms, test_tcp_tx_nb)
 
     EXPECT_EQ(server.received[0].endpointID, 2);
     EXPECT_EQ(server.received[0].data->size(), 4);
-    EXPECT_EQ(decodeTestPayload(server.received[0]),"abcd");
+    EXPECT_EQ(decodeTestPayload(server.received[0]), "abcd");
 }
 
 /** @brief Test lifecycle with a TX_ASYNC sent message. */
@@ -283,7 +280,7 @@ TEST(Comms, test_tcp_tx_async_0b)
 
     EXPECT_EQ(server.received[1].endpointID, 2);
     EXPECT_EQ(server.received[1].data->size(), 4);
-    EXPECT_EQ(decodeTestPayload(server.received[1]),"abcd");
+    EXPECT_EQ(decodeTestPayload(server.received[1]), "abcd");
 }
 
 /** @brief Test lifecycle with a TX_ASYNC sent message. */
@@ -305,11 +302,11 @@ TEST(Comms, test_tcp_tx_async_nb)
 
     EXPECT_EQ(server.received[0].endpointID, 1);
     EXPECT_EQ(server.received[0].data->size(), 4);
-    EXPECT_EQ(decodeTestPayload(server.received[0]),"abcd");
+    EXPECT_EQ(decodeTestPayload(server.received[0]), "abcd");
 
     EXPECT_EQ(server.received[1].endpointID, 2);
     EXPECT_EQ(server.received[1].data->size(), 3);
-    EXPECT_EQ(decodeTestPayload(server.received[1]),"efg");
+    EXPECT_EQ(decodeTestPayload(server.received[1]), "efg");
 }
 
 /** @brief Test lifecycle with a TX_RX sent message. */
@@ -349,9 +346,9 @@ TEST(Comms, test_tcp_tx_rx_nb)
 
     EXPECT_EQ(server.received[0].endpointID, 1);
     EXPECT_EQ(server.received[0].data->size(), 4);
-    EXPECT_EQ(decodeTestPayload(server.received[0]),"abcd");
+    EXPECT_EQ(decodeTestPayload(server.received[0]), "abcd");
 
     // Validate it was responded to correctly
     EXPECT_EQ(resps.size(), 4);
-    EXPECT_EQ(resps,"dcba");
+    EXPECT_EQ(resps, "dcba");
 }

--- a/source_common/comms/test/unittest_comms_client.cpp
+++ b/source_common/comms/test/unittest_comms_client.cpp
@@ -35,21 +35,19 @@
  * TODO: Get the test server to echo back tx and tx_async messages in a
  * subsequent tx_rx message.
  */
-#include <gtest/gtest.h>
-
 #include "comms/comms_interface.hpp"
 #include "comms/comms_module.hpp"
 
-std::unique_ptr<Comms::MessageData> makeTestPayload(
-    const std::string& str
-) {
+#include <gtest/gtest.h>
+
+std::unique_ptr<Comms::MessageData> makeTestPayload(const std::string& str)
+{
     auto data = std::make_unique<Comms::MessageData>(str.begin(), str.end());
     return data;
 }
 
-std::string decodeTestPayload(
-    std::unique_ptr<Comms::MessageData> data
-) {
+std::string decodeTestPayload(std::unique_ptr<Comms::MessageData> data)
+{
     std::string str(data->begin(), data->end());
     return str;
 }

--- a/source_common/framework/CMakeLists.txt
+++ b/source_common/framework/CMakeLists.txt
@@ -44,3 +44,5 @@ target_include_directories(
         ../../source_third_party/khronos/vulkan/include/)
 
 lgl_set_build_options(${LIB_BINARY})
+
+add_clang_tools()

--- a/source_common/framework/device_dispatch_table.hpp
+++ b/source_common/framework/device_dispatch_table.hpp
@@ -25,6 +25,8 @@
 
 #pragma once
 
+// clang-format off
+
 #include <vulkan/vulkan.h>
 
 #include "framework/device_functions.hpp"
@@ -1427,3 +1429,5 @@ static inline void initDriverDeviceDispatchTable(
 }
 
 #undef ENTRY
+
+// clang-format on

--- a/source_common/framework/device_functions.cpp
+++ b/source_common/framework/device_functions.cpp
@@ -23,6 +23,8 @@
  * ----------------------------------------------------------------------------
  */
 
+// clang-format off
+
 #include <mutex>
 
 // Include from per-layer code
@@ -7773,3 +7775,4 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkWriteMicromapsPropertiesEXT_default(
     return layer->driver.vkWriteMicromapsPropertiesEXT(device, micromapCount, pMicromaps, queryType, dataSize, pData, stride);
 }
 
+// clang-format on

--- a/source_common/framework/device_functions.hpp
+++ b/source_common/framework/device_functions.hpp
@@ -25,6 +25,8 @@
 
 #pragma once
 
+// clang-format off
+
 #include <vulkan/vulkan.h>
 
 /* See Vulkan API for documentation. */
@@ -7987,3 +7989,4 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkWriteMicromapsPropertiesEXT(
     return layer_vkWriteMicromapsPropertiesEXT_default(device, micromapCount, pMicromaps, queryType, dataSize, pData, stride);
 }
 
+// clang-format on

--- a/source_common/framework/device_query.cpp
+++ b/source_common/framework/device_query.cpp
@@ -23,28 +23,26 @@
  * ----------------------------------------------------------------------------
  */
 
-#include <vulkan/vulkan.h>
-
 #include "utils/misc.hpp"
 
+#include <vulkan/vulkan.h>
+
 /** See header for documentation. */
-bool isEnabledVkKhrTimelineSemaphore(
-    const VkDeviceCreateInfo& createInfo
-) {
+bool isEnabledVkKhrTimelineSemaphore(const VkDeviceCreateInfo& createInfo)
+{
     // Check Vulkan 1.2 core feature first
-    auto* coreFeature = searchNextList<VkPhysicalDeviceVulkan12Features>(
-        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES,
-        createInfo.pNext);
+    auto* coreFeature =
+        searchNextList<VkPhysicalDeviceVulkan12Features>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES,
+                                                         createInfo.pNext);
     if (coreFeature)
     {
         return coreFeature->timelineSemaphore;
     }
 
     // Check the extension second
-    bool extEnabled = isInExtensionList(
-      VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME,
-      createInfo.enabledExtensionCount,
-      createInfo.ppEnabledExtensionNames);
+    bool extEnabled = isInExtensionList(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME,
+                                        createInfo.enabledExtensionCount,
+                                        createInfo.ppEnabledExtensionNames);
     if (!extEnabled)
     {
         return false;

--- a/source_common/framework/device_query.hpp
+++ b/source_common/framework/device_query.hpp
@@ -30,9 +30,9 @@
 
 #pragma once
 
-#include <vulkan/vulkan.h>
-
 #include "utils/misc.hpp"
+
+#include <vulkan/vulkan.h>
 
 /**
  * Test if VK_KHR_timeline_semaphore (or equivalent core feature) is enabled.
@@ -41,5 +41,4 @@
  *
  * @return @c true if enabled, @c false otherwise.
  */
-bool isEnabledVkKhrTimelineSemaphore(
-    const VkDeviceCreateInfo& createInfo0);
+bool isEnabledVkKhrTimelineSemaphore(const VkDeviceCreateInfo& createInfo0);

--- a/source_common/framework/entry.cpp
+++ b/source_common/framework/entry.cpp
@@ -30,74 +30,67 @@
  * Note that the Android loader requires more functions to be exposed as
  * library symbols than other Vulkan loaders.
  */
-#include <mutex>
-
 #include "framework/device_functions.hpp"
 #include "framework/instance_functions.hpp"
 #include "framework/utils.hpp"
 
-#if __has_include ("layer_device_functions.hpp")
-    #include "layer_device_functions.hpp"
+#include <mutex>
+
+#if __has_include("layer_device_functions.hpp")
+#  include "layer_device_functions.hpp"
 #endif
 
-#if __has_include ("layer_instance_functions.hpp")
-    #include "layer_instance_functions.hpp"
+#if __has_include("layer_instance_functions.hpp")
+#  include "layer_instance_functions.hpp"
 #endif
 
 std::mutex g_vulkanLock;
 
-extern "C" {
-
+extern "C"
+{
 /** See Vulkan API for documentation. */
-VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(
-    VkDevice device,
-    const char* pName
-) {
+VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetDeviceProcAddr(VkDevice device, const char* pName)
+{
     return layer_vkGetDeviceProcAddr<user_tag>(device, pName);
 }
 
 /** See Vulkan API for documentation. */
-VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(
-    VkInstance instance,
-    const char* pName
-) {
+VK_LAYER_EXPORT VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance, const char* pName)
+{
     return layer_vkGetInstanceProcAddr<user_tag>(instance, pName);
 }
 
 /** See Vulkan API for documentation. */
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceExtensionProperties(
-    const char* pLayerName,
-    uint32_t* pPropertyCount,
-    VkExtensionProperties* pProperties
-) {
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL
+    vkEnumerateInstanceExtensionProperties(const char* pLayerName,
+                                           uint32_t* pPropertyCount,
+                                           VkExtensionProperties* pProperties)
+{
     return layer_vkEnumerateInstanceExtensionProperties<user_tag>(pLayerName, pPropertyCount, pProperties);
 }
 
 /** See Vulkan API for documentation. */
-VK_LAYER_EXPORT_ANDROID VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceExtensionProperties(
-    VkPhysicalDevice gpu,
-    const char* pLayerName,
-    uint32_t* pPropertyCount,
-    VkExtensionProperties* pProperties
-) {
+VK_LAYER_EXPORT_ANDROID VKAPI_ATTR VkResult VKAPI_CALL
+    vkEnumerateDeviceExtensionProperties(VkPhysicalDevice gpu,
+                                         const char* pLayerName,
+                                         uint32_t* pPropertyCount,
+                                         VkExtensionProperties* pProperties)
+{
     return layer_vkEnumerateDeviceExtensionProperties<user_tag>(gpu, pLayerName, pPropertyCount, pProperties);
 }
 
 /** See Vulkan API for documentation. */
-VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(
-    uint32_t* pPropertyCount,
-    VkLayerProperties* pProperties
-) {
+VK_LAYER_EXPORT VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateInstanceLayerProperties(uint32_t* pPropertyCount,
+                                                                                  VkLayerProperties* pProperties)
+{
     return layer_vkEnumerateInstanceLayerProperties<user_tag>(pPropertyCount, pProperties);
 }
 
 /** See Vulkan API for documentation. */
-VK_LAYER_EXPORT_ANDROID VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(
-    VkPhysicalDevice gpu,
-    uint32_t* pPropertyCount,
-    VkLayerProperties* pProperties
-) {
+VK_LAYER_EXPORT_ANDROID VKAPI_ATTR VkResult VKAPI_CALL vkEnumerateDeviceLayerProperties(VkPhysicalDevice gpu,
+                                                                                        uint32_t* pPropertyCount,
+                                                                                        VkLayerProperties* pProperties)
+{
     return layer_vkEnumerateDeviceLayerProperties<user_tag>(gpu, pPropertyCount, pProperties);
 }
-
 }

--- a/source_common/framework/instance_dispatch_table.hpp
+++ b/source_common/framework/instance_dispatch_table.hpp
@@ -25,6 +25,8 @@
 
 #pragma once
 
+// clang-format off
+
 #include <vulkan/vulkan.h>
 
 #include "framework/device_functions.hpp"
@@ -758,3 +760,5 @@ static inline void initDriverInstanceDispatchTable(
 }
 
 #undef ENTRY
+
+// clang-format on

--- a/source_common/framework/instance_functions.cpp
+++ b/source_common/framework/instance_functions.cpp
@@ -23,6 +23,8 @@
  * ----------------------------------------------------------------------------
  */
 
+// clang-format off
+
 #include <mutex>
 
 // Include from per-layer code
@@ -1203,3 +1205,4 @@ VKAPI_ATTR void VKAPI_CALL layer_vkSubmitDebugUtilsMessageEXT_default(
     layer->driver.vkSubmitDebugUtilsMessageEXT(instance, messageSeverity, messageTypes, pCallbackData);
 }
 
+// clang-format on

--- a/source_common/framework/instance_functions.hpp
+++ b/source_common/framework/instance_functions.hpp
@@ -25,6 +25,8 @@
 
 #pragma once
 
+// clang-format off
+
 #include <vulkan/vulkan.h>
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
@@ -1352,3 +1354,4 @@ VKAPI_ATTR void VKAPI_CALL layer_vkSubmitDebugUtilsMessageEXT(
     layer_vkSubmitDebugUtilsMessageEXT_default(instance, messageSeverity, messageTypes, pCallbackData);
 }
 
+// clang-format on

--- a/source_common/framework/manual_functions.cpp
+++ b/source_common/framework/manual_functions.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "framework/manual_functions.hpp"
+
 #include "utils/misc.hpp"
 
 /**
@@ -44,7 +45,7 @@ extern std::mutex g_vulkanLock;
 #define LGL_VERSION VK_MAKE_VERSION(LGL_VER_MAJOR, LGL_VER_MINOR, LGL_VER_PATCH)
 
 static const std::array<VkLayerProperties, 1> layerProps = {
-    {{ LGL_LAYER_NAME, LGL_VERSION, 1, LGL_LAYER_DESC }},
+    {{LGL_LAYER_NAME, LGL_VERSION, 1, LGL_LAYER_DESC}},
 };
 
 /**
@@ -66,19 +67,22 @@ struct DispatchTableEntry
 /**
  * @brief Utility macro to define a lookup for a core function.
  */
-#define VK_TABLE_ENTRY(func) \
-    { STR(func), reinterpret_cast<PFN_vkVoidFunction>(func) }
+#define VK_TABLE_ENTRY(func)                                                                                           \
+    {                                                                                                                  \
+        STR(func), reinterpret_cast<PFN_vkVoidFunction>(func)                                                          \
+    }
 
 /**
  * @brief Utility macro to define a lookup for a layer-dispatch-only function.
  */
-#define VK_TABLE_ENTRYL(func) \
-    { STR(func), reinterpret_cast<PFN_vkVoidFunction>(layer_##func) }
+#define VK_TABLE_ENTRYL(func)                                                                                          \
+    {                                                                                                                  \
+        STR(func), reinterpret_cast<PFN_vkVoidFunction>(layer_##func)                                                  \
+    }
 
 /* See header for documentation. */
-VkLayerInstanceCreateInfo* getChainInfo(
-    const VkInstanceCreateInfo* pCreateInfo
-) {
+VkLayerInstanceCreateInfo* getChainInfo(const VkInstanceCreateInfo* pCreateInfo)
+{
     auto* info = static_cast<const VkLayerInstanceCreateInfo*>(pCreateInfo->pNext);
     while (info)
     {
@@ -96,9 +100,8 @@ VkLayerInstanceCreateInfo* getChainInfo(
 }
 
 /* See header for documentation. */
-VkLayerDeviceCreateInfo* getChainInfo(
-    const VkDeviceCreateInfo* pCreateInfo
-) {
+VkLayerDeviceCreateInfo* getChainInfo(const VkDeviceCreateInfo* pCreateInfo)
+{
     auto* info = static_cast<const VkLayerDeviceCreateInfo*>(pCreateInfo->pNext);
     while (info)
     {
@@ -116,9 +119,8 @@ VkLayerDeviceCreateInfo* getChainInfo(
 }
 
 /* See header for documentation. */
-PFN_vkVoidFunction getFixedInstanceLayerFunction(
-    const char* name
-) {
+PFN_vkVoidFunction getFixedInstanceLayerFunction(const char* name)
+{
     static const DispatchTableEntry layerFunctions[] = {
         VK_TABLE_ENTRY(vkGetInstanceProcAddr),
         VK_TABLE_ENTRY(vkEnumerateDeviceLayerProperties),
@@ -127,7 +129,7 @@ PFN_vkVoidFunction getFixedInstanceLayerFunction(
         VK_TABLE_ENTRY(vkEnumerateInstanceExtensionProperties),
     };
 
-    for (auto &function : layerFunctions)
+    for (auto& function : layerFunctions)
     {
         if (!strcmp(function.name, name))
         {
@@ -139,10 +141,9 @@ PFN_vkVoidFunction getFixedInstanceLayerFunction(
 }
 
 /* See header for documentation. */
-PFN_vkVoidFunction getInstanceLayerFunction(
-    const char* name
-) {
-    for (auto &function : instanceIntercepts)
+PFN_vkVoidFunction getInstanceLayerFunction(const char* name)
+{
+    for (auto& function : instanceIntercepts)
     {
         if (!strcmp(function.name, name))
         {
@@ -154,16 +155,15 @@ PFN_vkVoidFunction getInstanceLayerFunction(
 }
 
 /* See header for documentation. */
-PFN_vkVoidFunction getDeviceLayerFunction(
-    const char* name
-) {
+PFN_vkVoidFunction getDeviceLayerFunction(const char* name)
+{
     static const DispatchTableEntry layerFunctions[] = {
         VK_TABLE_ENTRY(vkGetDeviceProcAddr),
         VK_TABLE_ENTRY(vkEnumerateDeviceExtensionProperties),
         VK_TABLE_ENTRY(vkEnumerateDeviceLayerProperties),
     };
 
-    for (auto &function : layerFunctions)
+    for (auto& function : layerFunctions)
     {
         if (!strcmp(function.name, name))
         {
@@ -171,7 +171,7 @@ PFN_vkVoidFunction getDeviceLayerFunction(
         }
     }
 
-    for (auto &function : deviceIntercepts)
+    for (auto& function : deviceIntercepts)
     {
         if (!strcmp(function.name, name))
         {
@@ -183,9 +183,8 @@ PFN_vkVoidFunction getDeviceLayerFunction(
 }
 
 /* See header for documentation. */
-APIVersion getInstanceAPIVersion(
-    PFN_vkGetInstanceProcAddr fpGetProcAddr
-) {
+APIVersion getInstanceAPIVersion(PFN_vkGetInstanceProcAddr fpGetProcAddr)
+{
     // TODO: This will crash in Khronos validation if we try to use this
     // with the validation layer beneath us due to Android loader v0 protocol.
 #if 0
@@ -197,7 +196,7 @@ APIVersion getInstanceAPIVersion(
     if (!fpFunction)
     {
         LAYER_ERR("Failed to get vkEnumerateInstanceVersion()");
-        return { 0 , 0 };
+        return {0, 0};
     }
 
     uint32_t apiVersion = 0;
@@ -205,36 +204,34 @@ APIVersion getInstanceAPIVersion(
     if (result != VK_SUCCESS)
     {
         LAYER_ERR("Failed to call vkEnumerateInstanceVersion()");
-        return { 0 , 0 };
+        return {0, 0};
     }
 
     uint32_t major = VK_API_VERSION_MAJOR(apiVersion);
     uint32_t minor = VK_API_VERSION_MINOR(apiVersion);
-    return { major, minor };
+    return {major, minor};
 }
 
 /* See header for documentation. */
-APIVersion getApplicationAPIVersion(
-    const VkInstanceCreateInfo* pCreateInfo
-) {
+APIVersion getApplicationAPIVersion(const VkInstanceCreateInfo* pCreateInfo)
+{
     uint32_t apiVersion = pCreateInfo->pApplicationInfo->apiVersion;
     uint32_t major = VK_API_VERSION_MAJOR(apiVersion);
     uint32_t minor = VK_API_VERSION_MINOR(apiVersion);
-    return { major, minor };
+    return {major, minor};
 }
 
 /* See header for documentation. */
-APIVersion getDeviceAPIVersion(
-    PFN_vkGetInstanceProcAddr fpGetProcAddr,
-    VkInstance instance,
-    VkPhysicalDevice physicalDevice
-) {
+APIVersion getDeviceAPIVersion(PFN_vkGetInstanceProcAddr fpGetProcAddr,
+                               VkInstance instance,
+                               VkPhysicalDevice physicalDevice)
+{
     auto fpFunctionRaw = fpGetProcAddr(instance, "vkGetPhysicalDeviceProperties");
     auto fpFunction = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties>(fpFunctionRaw);
     if (!fpFunction)
     {
         LAYER_ERR("Failed to get vkGetPhysicalDeviceProperties()");
-        return { 0 , 0 };
+        return {0, 0};
     }
 
     VkPhysicalDeviceProperties properties {};
@@ -242,18 +239,16 @@ APIVersion getDeviceAPIVersion(
 
     uint32_t major = VK_API_VERSION_MAJOR(properties.apiVersion);
     uint32_t minor = VK_API_VERSION_MINOR(properties.apiVersion);
-    return { major, minor };
+    return {major, minor};
 }
 
 /**
  * @brief Is version A >= version B.
  */
-static bool isVersionGreaterEqual(
-    const APIVersion& a,
-    const APIVersion& b
-) {
+static bool isVersionGreaterEqual(const APIVersion& a, const APIVersion& b)
+{
     // Different major version
-    if(a.first != b.first)
+    if (a.first != b.first)
     {
         return a.first > b.first;
     }
@@ -265,12 +260,10 @@ static bool isVersionGreaterEqual(
 /**
  * @brief Is version A > version B.
  */
-static bool isVersionGreater(
-    const APIVersion& a,
-    const APIVersion& b
-) {
+static bool isVersionGreater(const APIVersion& a, const APIVersion& b)
+{
     // Different major version
-    if(a.first != b.first)
+    if (a.first != b.first)
     {
         return a.first > b.first;
     }
@@ -280,43 +273,37 @@ static bool isVersionGreater(
 }
 
 /* See header for documentation. */
-APIVersion increaseAPIVersion(
-    const APIVersion& userVersion,
-    const APIVersion& maxVersion,
-    const APIVersion& requiredVersion
-) {
+APIVersion increaseAPIVersion(const APIVersion& userVersion,
+                              const APIVersion& maxVersion,
+                              const APIVersion& requiredVersion)
+{
     // User version is good enough to support the layer, so stick with that
-    if(isVersionGreaterEqual(userVersion, requiredVersion))
+    if (isVersionGreaterEqual(userVersion, requiredVersion))
     {
-        LAYER_LOG(
-            "Instance API version %u.%u (user setting meets layer minimum)",
-            userVersion.first, userVersion.second);
+        LAYER_LOG("Instance API version %u.%u (user setting meets layer minimum)",
+                  userVersion.first,
+                  userVersion.second);
 
         return userVersion;
     }
 
     // Required version is higher than the max version so log a warning
     // and try to continue using maxVersion but it may fail ...
-    if(isVersionGreater(requiredVersion, maxVersion))
+    if (isVersionGreater(requiredVersion, maxVersion))
     {
-        LAYER_ERR(
-            "Instance API version %u.%u (lower than layer minimum)",
-            maxVersion.first, maxVersion.second);
+        LAYER_ERR("Instance API version %u.%u (lower than layer minimum)", maxVersion.first, maxVersion.second);
 
         return maxVersion;
     }
 
-    LAYER_LOG(
-        "Instance API version %u.%u (increased to layer minimum)",
-        requiredVersion.first, requiredVersion.second);
+    LAYER_LOG("Instance API version %u.%u (increased to layer minimum)", requiredVersion.first, requiredVersion.second);
 
     return requiredVersion;
 }
 
 /* See header for documentation. */
-std::vector<std::string> getInstanceExtensionList(
-    const VkInstanceCreateInfo* pCreateInfo
-) {
+std::vector<std::string> getInstanceExtensionList(const VkInstanceCreateInfo* pCreateInfo)
+{
     std::vector<std::string> foundExtensions;
 
     // Fetch the functions needed to query extensions availability
@@ -348,11 +335,10 @@ std::vector<std::string> getInstanceExtensionList(
 }
 
 /* See header for documentation. */
-std::vector<std::string> getDeviceExtensionList(
-    VkInstance instance,
-    VkPhysicalDevice physicalDevice,
-    const VkDeviceCreateInfo* pCreateInfo
-) {
+std::vector<std::string> getDeviceExtensionList(VkInstance instance,
+                                                VkPhysicalDevice physicalDevice,
+                                                const VkDeviceCreateInfo* pCreateInfo)
+{
     std::vector<std::string> foundExtensions;
 
     // Fetch the functions needed to query extensions availability
@@ -384,12 +370,10 @@ std::vector<std::string> getDeviceExtensionList(
 }
 
 /* See header for documentation. */
-std::vector<const char*> cloneExtensionList(
-    uint32_t extensionCount,
-    const char* const* extensionList
-) {
+std::vector<const char*> cloneExtensionList(uint32_t extensionCount, const char* const* extensionList)
+{
     std::vector<const char*> data;
-    for(uint32_t i = 0; i < extensionCount; i++)
+    for (uint32_t i = 0; i < extensionCount; i++)
     {
         data.emplace_back(extensionList[i]);
     }
@@ -405,11 +389,9 @@ std::vector<const char*> cloneExtensionList(
  * @param supported   The list of supported extension, or empty if unknown.
  * @param active      The list of active extensions.
  */
-static void enableInstanceVkExtDebugUtils(
-    const std::vector<std::string>& supported,
-    std::vector<const char*>& active
-) {
-    static const std::string target { VK_EXT_DEBUG_UTILS_EXTENSION_NAME };
+static void enableInstanceVkExtDebugUtils(const std::vector<std::string>& supported, std::vector<const char*>& active)
+{
+    static const std::string target {VK_EXT_DEBUG_UTILS_EXTENSION_NAME};
 
     // Test if the desired extension is supported. If supported list is
     // empty then we didn't query and assume extension is supported.
@@ -446,13 +428,12 @@ static void enableInstanceVkExtDebugUtils(
  * @param active        The list of active extensions.
  * @param newFeatures   Pre-allocated struct we can use if we need to add it.
  */
-static void enableDeviceVkKhrTimelineSemaphore(
-    VkDeviceCreateInfo& createInfo,
-    std::vector<std::string>& supported,
-    std::vector<const char*>& active,
-    VkPhysicalDeviceTimelineSemaphoreFeatures newFeatures
-) {
-    static const std::string target { VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME };
+static void enableDeviceVkKhrTimelineSemaphore(VkDeviceCreateInfo& createInfo,
+                                               std::vector<std::string>& supported,
+                                               std::vector<const char*>& active,
+                                               VkPhysicalDeviceTimelineSemaphoreFeatures newFeatures)
+{
+    static const std::string target {VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME};
 
     // Test if the desired extension is supported
     if (!isIn(target, supported))
@@ -491,9 +472,9 @@ static void enableDeviceVkKhrTimelineSemaphore(
     // Check if user provided a VkPhysicalDeviceVulkan12Features
     // TODO: This currently relies on const_cast to make user struct writable
     //       We should replace this with a generic clone (issue #56)
-    auto* config2 = searchNextList<VkPhysicalDeviceVulkan12Features>(
-        VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES,
-        createInfo.pNext);
+    auto* config2 =
+        searchNextList<VkPhysicalDeviceVulkan12Features>(VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES,
+                                                         createInfo.pNext);
 
     if (config2)
     {
@@ -533,13 +514,12 @@ static void enableDeviceVkKhrTimelineSemaphore(
  * @param active        The list of active extensions.
  * @param newFeatures   Pre-allocated struct we can use if we need to add it.
  */
-static void enableDeviceVkExtImageCompressionControl(
-    VkDeviceCreateInfo& createInfo,
-    std::vector<std::string>& supported,
-    std::vector<const char*>& active,
-    VkPhysicalDeviceImageCompressionControlFeaturesEXT newFeatures
-) {
-    static const std::string target { VK_EXT_IMAGE_COMPRESSION_CONTROL_EXTENSION_NAME };
+static void enableDeviceVkExtImageCompressionControl(VkDeviceCreateInfo& createInfo,
+                                                     std::vector<std::string>& supported,
+                                                     std::vector<const char*>& active,
+                                                     VkPhysicalDeviceImageCompressionControlFeaturesEXT newFeatures)
+{
+    static const std::string target {VK_EXT_IMAGE_COMPRESSION_CONTROL_EXTENSION_NAME};
 
     // Test if the desired extension is supported
     if (!isIn(target, supported))
@@ -588,10 +568,8 @@ static void enableDeviceVkExtImageCompressionControl(
 }
 
 /** See Vulkan API for documentation. */
-PFN_vkVoidFunction layer_vkGetInstanceProcAddr_default(
-    VkInstance instance,
-    const char* pName
-) {
+PFN_vkVoidFunction layer_vkGetInstanceProcAddr_default(VkInstance instance, const char* pName)
+{
     // Always expose these functions ...
     PFN_vkVoidFunction layerFunction = getFixedInstanceLayerFunction(pName);
     if (layerFunction)
@@ -602,8 +580,9 @@ PFN_vkVoidFunction layer_vkGetInstanceProcAddr_default(
     // Otherwise, only expose functions that the driver exposes to avoid
     // changing queryable interface behavior seen by the application
     layerFunction = getInstanceLayerFunction(pName);
-    if (instance) {
-        std::unique_lock<std::mutex> lock { g_vulkanLock };
+    if (instance)
+    {
+        std::unique_lock<std::mutex> lock {g_vulkanLock};
         auto* layer = Instance::retrieve(instance);
 
         // Don't hold the lock while calling the driver
@@ -624,12 +603,10 @@ PFN_vkVoidFunction layer_vkGetInstanceProcAddr_default(
 }
 
 /** See Vulkan API for documentation. */
-PFN_vkVoidFunction layer_vkGetDeviceProcAddr_default(
-    VkDevice device,
-    const char* pName
-) {
+PFN_vkVoidFunction layer_vkGetDeviceProcAddr_default(VkDevice device, const char* pName)
+{
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(device);
     lock.unlock();
 
@@ -649,11 +626,10 @@ PFN_vkVoidFunction layer_vkGetDeviceProcAddr_default(
 }
 
 /** See Vulkan API for documentation. */
-VkResult layer_vkEnumerateInstanceExtensionProperties_default(
-    const char* pLayerName,
-    uint32_t* pPropertyCount,
-    VkExtensionProperties* pProperties
-) {
+VkResult layer_vkEnumerateInstanceExtensionProperties_default(const char* pLayerName,
+                                                              uint32_t* pPropertyCount,
+                                                              VkExtensionProperties* pProperties)
+{
     LAYER_TRACE(__func__);
 
     UNUSED(pProperties);
@@ -668,12 +644,11 @@ VkResult layer_vkEnumerateInstanceExtensionProperties_default(
 }
 
 /** See Vulkan API for documentation. */
-VkResult layer_vkEnumerateDeviceExtensionProperties_default(
-    VkPhysicalDevice gpu,
-    const char* pLayerName,
-    uint32_t* pPropertyCount,
-    VkExtensionProperties* pProperties
-) {
+VkResult layer_vkEnumerateDeviceExtensionProperties_default(VkPhysicalDevice gpu,
+                                                            const char* pLayerName,
+                                                            uint32_t* pPropertyCount,
+                                                            VkExtensionProperties* pProperties)
+{
     LAYER_TRACE(__func__);
 
     UNUSED(pProperties);
@@ -694,7 +669,7 @@ VkResult layer_vkEnumerateDeviceExtensionProperties_default(
     assert(!pLayerName);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Instance::retrieve(gpu);
 
     // Release the lock to call into the driver
@@ -703,10 +678,8 @@ VkResult layer_vkEnumerateDeviceExtensionProperties_default(
 }
 
 /** See Vulkan API for documentation. */
-VkResult layer_vkEnumerateInstanceLayerProperties_default(
-    uint32_t* pPropertyCount,
-    VkLayerProperties* pProperties
-) {
+VkResult layer_vkEnumerateInstanceLayerProperties_default(uint32_t* pPropertyCount, VkLayerProperties* pProperties)
+{
     LAYER_TRACE(__func__);
 
     if (pProperties)
@@ -727,11 +700,10 @@ VkResult layer_vkEnumerateInstanceLayerProperties_default(
 }
 
 /** See Vulkan API for documentation. */
-VkResult layer_vkEnumerateDeviceLayerProperties_default(
-    VkPhysicalDevice gpu,
-    uint32_t* pPropertyCount,
-    VkLayerProperties* pProperties
-) {
+VkResult layer_vkEnumerateDeviceLayerProperties_default(VkPhysicalDevice gpu,
+                                                        uint32_t* pPropertyCount,
+                                                        VkLayerProperties* pProperties)
+{
     LAYER_TRACE(__func__);
 
     UNUSED(gpu);
@@ -754,11 +726,10 @@ VkResult layer_vkEnumerateDeviceLayerProperties_default(
 }
 
 /* See Vulkan API for documentation. */
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateInstance_default(
-    const VkInstanceCreateInfo* pCreateInfo,
-    const VkAllocationCallbacks* pAllocator,
-    VkInstance* pInstance
-) {
+VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateInstance_default(const VkInstanceCreateInfo* pCreateInfo,
+                                                              const VkAllocationCallbacks* pAllocator,
+                                                              VkInstance* pInstance)
+{
     LAYER_TRACE(__func__);
 
     // We cannot reliably query the available instance extensions on Android if multiple layers are
@@ -806,7 +777,7 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateInstance_default(
     newCreateInfo.pApplicationInfo = &newAppInfo;
 
     // Create a copy of the extension list we can patch
-    std::vector<const char *> newExtensions;
+    std::vector<const char*> newExtensions;
     const auto start = pCreateInfo->ppEnabledExtensionNames;
     const auto end = pCreateInfo->ppEnabledExtensionNames + pCreateInfo->enabledExtensionCount;
     newExtensions.insert(newExtensions.end(), start, end);
@@ -816,9 +787,7 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateInstance_default(
     {
         if (newExt == VK_EXT_DEBUG_UTILS_EXTENSION_NAME)
         {
-            enableInstanceVkExtDebugUtils(
-                supportedExtensions,
-                newExtensions);
+            enableInstanceVkExtDebugUtils(supportedExtensions, newExtensions);
         }
         else
         {
@@ -846,12 +815,10 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateInstance_default(
     }
 
     // Retake the lock to access layer-wide global store
-    auto instance = std::make_unique<Instance>(
-        *pInstance,
-        fpGetInstanceProcAddr);
+    auto instance = std::make_unique<Instance>(*pInstance, fpGetInstanceProcAddr);
 
     {
-        std::lock_guard<std::mutex> lock { g_vulkanLock };
+        std::lock_guard<std::mutex> lock {g_vulkanLock};
         Instance::store(*pInstance, instance);
     }
 
@@ -859,14 +826,12 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateInstance_default(
 }
 
 /* See Vulkan API for documentation. */
-VKAPI_ATTR void VKAPI_CALL layer_vkDestroyInstance_default(
-    VkInstance instance,
-    const VkAllocationCallbacks* pAllocator
-) {
+VKAPI_ATTR void VKAPI_CALL layer_vkDestroyInstance_default(VkInstance instance, const VkAllocationCallbacks* pAllocator)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Instance::retrieve(instance);
 
     // Layer proxy must be destroyed before the driver version
@@ -876,20 +841,18 @@ VKAPI_ATTR void VKAPI_CALL layer_vkDestroyInstance_default(
     // Release the lock to call into the driver
     lock.unlock();
     layer->driver.vkDestroyInstance(instance, pAllocator);
-
 }
 
 /* See Vulkan API for documentation. */
-VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateDevice_default(
-    VkPhysicalDevice physicalDevice,
-    const VkDeviceCreateInfo* pCreateInfo,
-    const VkAllocationCallbacks* pAllocator,
-    VkDevice* pDevice
-) {
+VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateDevice_default(VkPhysicalDevice physicalDevice,
+                                                            const VkDeviceCreateInfo* pCreateInfo,
+                                                            const VkAllocationCallbacks* pAllocator,
+                                                            VkDevice* pDevice)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Instance::retrieve(physicalDevice);
 
     // Release the lock to call into the driver
@@ -904,8 +867,7 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateDevice_default(
     auto fpGetDeviceProcAddr = chainInfo->u.pLayerInfo->pfnNextGetDeviceProcAddr;
 
     // Log this for support purposes ...
-    APIVersion apiVersion = getDeviceAPIVersion(
-        fpGetInstanceProcAddr, layer->instance, physicalDevice);
+    APIVersion apiVersion = getDeviceAPIVersion(fpGetInstanceProcAddr, layer->instance, physicalDevice);
 
     LAYER_LOG("Device API version %u.%u", apiVersion.first, apiVersion.second);
 
@@ -917,7 +879,7 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateDevice_default(
     VkPhysicalDeviceImageCompressionControlFeaturesEXT newCompressionControlFeatures;
 
     // Create a copy of the extension list we can patch
-    std::vector<const char *> newExtensions;
+    std::vector<const char*> newExtensions;
     const auto start = pCreateInfo->ppEnabledExtensionNames;
     const auto end = pCreateInfo->ppEnabledExtensionNames + pCreateInfo->enabledExtensionCount;
     newExtensions.insert(newExtensions.end(), start, end);
@@ -927,19 +889,14 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateDevice_default(
     {
         if (newExt == VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME)
         {
-            enableDeviceVkKhrTimelineSemaphore(
-                newCreateInfo,
-                supportedExtensions,
-                newExtensions,
-                newTimelineFeatures);
+            enableDeviceVkKhrTimelineSemaphore(newCreateInfo, supportedExtensions, newExtensions, newTimelineFeatures);
         }
         else if (newExt == VK_EXT_IMAGE_COMPRESSION_CONTROL_EXTENSION_NAME)
         {
-            enableDeviceVkExtImageCompressionControl(
-                newCreateInfo,
-                supportedExtensions,
-                newExtensions,
-                newCompressionControlFeatures);
+            enableDeviceVkExtImageCompressionControl(newCreateInfo,
+                                                     supportedExtensions,
+                                                     newExtensions,
+                                                     newCompressionControlFeatures);
         }
         else
         {
@@ -974,8 +931,7 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateDevice_default(
         return res;
     }
 
-    auto device = std::make_unique<Device>(
-        layer, physicalDevice, *pDevice, fpGetDeviceProcAddr, newCreateInfo);
+    auto device = std::make_unique<Device>(layer, physicalDevice, *pDevice, fpGetDeviceProcAddr, newCreateInfo);
 
     // Retake the lock to access layer-wide global store
     lock.lock();
@@ -985,14 +941,12 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateDevice_default(
 }
 
 /* See Vulkan API for documentation. */
-VKAPI_ATTR void VKAPI_CALL layer_vkDestroyDevice_default(
-    VkDevice device,
-    const VkAllocationCallbacks* pAllocator
-) {
+VKAPI_ATTR void VKAPI_CALL layer_vkDestroyDevice_default(VkDevice device, const VkAllocationCallbacks* pAllocator)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(device);
 
     // Layer proxy must be destroyed before the driver version
@@ -1005,15 +959,15 @@ VKAPI_ATTR void VKAPI_CALL layer_vkDestroyDevice_default(
 }
 
 /* See Vulkan API for documentation. */
-VKAPI_ATTR void VKAPI_CALL layer_vkGetDeviceImageMemoryRequirementsKHR_default(
-    VkDevice device,
-    const VkDeviceImageMemoryRequirements* pInfo,
-    VkMemoryRequirements2* pMemoryRequirements
-) {
+VKAPI_ATTR void VKAPI_CALL
+    layer_vkGetDeviceImageMemoryRequirementsKHR_default(VkDevice device,
+                                                        const VkDeviceImageMemoryRequirements* pInfo,
+                                                        VkMemoryRequirements2* pMemoryRequirements)
+{
     LAYER_TRACE(__func__);
 
     // Hold the lock to access layer-wide global store
-    std::unique_lock<std::mutex> lock { g_vulkanLock };
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
     auto* layer = Device::retrieve(device);
 
     // Workaround Unreal Engine trying to invoke this via a function pointer

--- a/source_common/framework/manual_functions.hpp
+++ b/source_common/framework/manual_functions.hpp
@@ -29,21 +29,20 @@
  * implemented as library code which can be swapped for alternative
  * implementations on a per-layer basis if needed.
  */
+#include "device.hpp"
+#include "framework/device_dispatch_table.hpp"
+#include "framework/device_functions.hpp"
+#include "framework/instance_functions.hpp"
+#include "framework/utils.hpp"
+#include "instance.hpp"
+#include "version.hpp"
+
 #include <array>
 #include <cstring>
 #include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
-
-#include "device.hpp"
-#include "instance.hpp"
-#include "version.hpp"
-
-#include "framework/device_dispatch_table.hpp"
-#include "framework/device_functions.hpp"
-#include "framework/instance_functions.hpp"
-#include "framework/utils.hpp"
 
 /**
  * @brief Extract the layer chain info from the instance creation info.
@@ -52,8 +51,7 @@
  *
  * @return The instance creation info, or @c nullptr if not found.
  */
-VkLayerInstanceCreateInfo* getChainInfo(
-    const VkInstanceCreateInfo* pCreateInfo);
+VkLayerInstanceCreateInfo* getChainInfo(const VkInstanceCreateInfo* pCreateInfo);
 
 /**
  * @brief Extract the layer chain info from the device creation info.
@@ -62,8 +60,7 @@ VkLayerInstanceCreateInfo* getChainInfo(
  *
  * @return The instance creation info, or @c nullptr if not found.
  */
-VkLayerDeviceCreateInfo* getChainInfo(
-    const VkDeviceCreateInfo* pCreateInfo);
+VkLayerDeviceCreateInfo* getChainInfo(const VkDeviceCreateInfo* pCreateInfo);
 
 /**
  * @brief Fetch the function for a given static instance entrypoint name.
@@ -76,8 +73,7 @@ VkLayerDeviceCreateInfo* getChainInfo(
  * @return The layer function pointer, or \c nullptr if the layer doesn't
  *         intercept the function.
  */
-PFN_vkVoidFunction getFixedInstanceLayerFunction(
-    const char* name);
+PFN_vkVoidFunction getFixedInstanceLayerFunction(const char* name);
 
 /**
  * @brief Fetch the function for a given dynamic instance entrypoint name.
@@ -90,8 +86,7 @@ PFN_vkVoidFunction getFixedInstanceLayerFunction(
  * @return The layer function pointer, or \c nullptr if the layer doesn't
  *         intercept the function.
  */
-PFN_vkVoidFunction getInstanceLayerFunction(
-    const char* name);
+PFN_vkVoidFunction getInstanceLayerFunction(const char* name);
 
 /**
  * @brief Fetch the function for a given dynamic instance entrypoint name.
@@ -104,8 +99,7 @@ PFN_vkVoidFunction getInstanceLayerFunction(
  * @return The layer function pointer, or \c nullptr if the layer doesn't
  *         intercept the function.
  */
-PFN_vkVoidFunction getDeviceLayerFunction(
-    const char* name);
+PFN_vkVoidFunction getDeviceLayerFunction(const char* name);
 
 /**
  * @brief Fetch the maximum supported instance API version.
@@ -114,8 +108,7 @@ PFN_vkVoidFunction getDeviceLayerFunction(
  *
  * @return The major/minor version numbers, or zeros on error.
  */
-APIVersion getInstanceAPIVersion(
-    PFN_vkGetInstanceProcAddr fpGetProcAddr);
+APIVersion getInstanceAPIVersion(PFN_vkGetInstanceProcAddr fpGetProcAddr);
 
 /**
  * @brief Fetch the application requested instance API version.
@@ -124,8 +117,7 @@ APIVersion getInstanceAPIVersion(
  *
  * @return The major/minor version numbers.
  */
-APIVersion getApplicationAPIVersion(
-    const VkInstanceCreateInfo* pCreateInfo);
+APIVersion getApplicationAPIVersion(const VkInstanceCreateInfo* pCreateInfo);
 
 /**
  * @brief Fetch the maximum supported device API version.
@@ -136,10 +128,9 @@ APIVersion getApplicationAPIVersion(
  *
  * @return The major/minor version numbers, or zeros on error.
  */
-APIVersion getDeviceAPIVersion(
-    PFN_vkGetInstanceProcAddr fpGetProcAddr,
-    VkInstance instance,
-    VkPhysicalDevice physicalDevice);
+APIVersion getDeviceAPIVersion(PFN_vkGetInstanceProcAddr fpGetProcAddr,
+                               VkInstance instance,
+                               VkPhysicalDevice physicalDevice);
 
 /**
  * @brief Return an increased API version, if supported.
@@ -150,10 +141,9 @@ APIVersion getDeviceAPIVersion(
  *
  * @return The major/minor version numbers, or zeros on error.
  */
-APIVersion increaseAPIVersion(
-    const APIVersion& userVersion,
-    const APIVersion& maxVersion,
-    const APIVersion& requiredVersion);
+APIVersion increaseAPIVersion(const APIVersion& userVersion,
+                              const APIVersion& maxVersion,
+                              const APIVersion& requiredVersion);
 
 /**
  * @brief Fetch the list of supported extensions from the instance.
@@ -167,8 +157,7 @@ APIVersion increaseAPIVersion(
  *
  * @return The list of supported extensions; empty list on failure.
  */
-std::vector<std::string> getInstanceExtensionList(
-    const VkInstanceCreateInfo* pCreateInfo);
+std::vector<std::string> getInstanceExtensionList(const VkInstanceCreateInfo* pCreateInfo);
 
 /**
  * @brief Fetch the list of supported extensions from a physical device.
@@ -179,10 +168,9 @@ std::vector<std::string> getInstanceExtensionList(
  *
  * @return The list of supported extensions; empty list on failure.
  */
-std::vector<std::string> getDeviceExtensionList(
-    VkInstance instance,
-    VkPhysicalDevice physicalDevice,
-    const VkDeviceCreateInfo* pCreateInfo);
+std::vector<std::string> getDeviceExtensionList(VkInstance instance,
+                                                VkPhysicalDevice physicalDevice,
+                                                const VkDeviceCreateInfo* pCreateInfo);
 
 /**
  * @brief Clone the target extension list.
@@ -192,6 +180,4 @@ std::vector<std::string> getDeviceExtensionList(
  *
  * @return the cloned list.
  */
-std::vector<const char*> cloneExtensionList(
-    uint32_t extensionCount,
-    const char* const* extensionList);
+std::vector<const char*> cloneExtensionList(uint32_t extensionCount, const char* const* extensionList);

--- a/source_common/framework/utils.hpp
+++ b/source_common/framework/utils.hpp
@@ -38,7 +38,7 @@
 #include <sys/time.h>
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-  #include <android/log.h>
+#  include <android/log.h>
 #endif
 
 /**
@@ -50,9 +50,9 @@
  * Annotation for exported symbol from shared object on Android only.
  */
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
-    #define VK_LAYER_EXPORT_ANDROID VK_LAYER_EXPORT
+#  define VK_LAYER_EXPORT_ANDROID VK_LAYER_EXPORT
 #else
-    #define VK_LAYER_EXPORT_ANDROID
+#  define VK_LAYER_EXPORT_ANDROID
 #endif
 
 /**
@@ -63,7 +63,9 @@ using APIVersion = std::pair<uint32_t, uint32_t>;
 /**
  * @brief Tag type used for template function dispatch;
  */
-struct user_tag {};
+struct user_tag
+{
+};
 
 /**
  * @brief Convert a dispatchable API handle to the underlying dispatch key.
@@ -72,9 +74,8 @@ struct user_tag {};
  *
  * @return The dispatch key.
  */
-static inline void* getDispatchKey(
-    void* ptr
-) {
+inline static void* getDispatchKey(void* ptr)
+{
     return *static_cast<void**>(ptr);
 }
 
@@ -82,43 +83,47 @@ static inline void* getDispatchKey(
  * @brief Enable to enable API entrypoint tracing to the log/logcat.
  */
 #if !defined(CONFIG_TRACE)
-  #define CONFIG_TRACE 0
+#  define CONFIG_TRACE 0
 #endif
 
 /**
  * @brief Enable to enable layer logging to the log/logcat.
  */
 #if !defined(CONFIG_LOG)
-  #define CONFIG_LOG 1
+#  define CONFIG_LOG 1
 #endif
 
 #if CONFIG_TRACE
-  #ifdef __ANDROID__
-    #if !defined(LGL_LOG_TAG)
-        #error "LGL_LOG_TAG not defined"
-    #endif
+#  ifdef __ANDROID__
+#    if !defined(LGL_LOG_TAG)
+#      error "LGL_LOG_TAG not defined"
+#    endif
 
-    #define LAYER_TRACE(x) __android_log_print(ANDROID_LOG_INFO, LGL_LOG_TAG, "API Trace: %s", x)
-  #else
-    #define LAYER_TRACE(x) printf("API Trace: %s\n", x)
-  #endif
+#    define LAYER_TRACE(x) __android_log_print(ANDROID_LOG_INFO, LGL_LOG_TAG, "API Trace: %s", x)
+#  else
+#    define LAYER_TRACE(x) printf("API Trace: %s\n", x)
+#  endif
 #else
-    #define LAYER_TRACE(x)
+#  define LAYER_TRACE(x)
 #endif
 
 #if CONFIG_LOG
-  #ifdef __ANDROID__
-    #if !defined(LGL_LOG_TAG)
-        #error "LGL_LOG_TAG not defined"
-    #endif
+#  ifdef __ANDROID__
+#    if !defined(LGL_LOG_TAG)
+#      error "LGL_LOG_TAG not defined"
+#    endif
 
-    #define LAYER_LOG(...) __android_log_print(ANDROID_LOG_INFO, LGL_LOG_TAG, __VA_ARGS__)
-    #define LAYER_ERR(...) __android_log_print(ANDROID_LOG_INFO, LGL_LOG_TAG, __VA_ARGS__)
-  #else
-    #define LAYER_LOG(...) printf(__VA_ARGS__); printf("\n");
-    #define LAYER_ERR(...) printf(__VA_ARGS__); printf("\n");
-  #endif
+#    define LAYER_LOG(...) __android_log_print(ANDROID_LOG_INFO, LGL_LOG_TAG, __VA_ARGS__)
+#    define LAYER_ERR(...) __android_log_print(ANDROID_LOG_INFO, LGL_LOG_TAG, __VA_ARGS__)
+#  else
+#    define LAYER_LOG(...)                                                                                             \
+        printf(__VA_ARGS__);                                                                                           \
+        printf("\n");
+#    define LAYER_ERR(...)                                                                                             \
+        printf(__VA_ARGS__);                                                                                           \
+        printf("\n");
+#  endif
 #else
-    #define LAYER_LOG(...)
-    #define LAYER_ERR(...)
+#  define LAYER_LOG(...)
+#  define LAYER_ERR(...)
 #endif

--- a/source_common/trackers/CMakeLists.txt
+++ b/source_common/trackers/CMakeLists.txt
@@ -44,3 +44,4 @@ lgl_set_build_options(${LIB_BINARY})
 #    add_subdirectory(test)
 #endif()
 
+add_clang_tools()

--- a/source_common/trackers/command_buffer.cpp
+++ b/source_common/trackers/command_buffer.cpp
@@ -23,22 +23,21 @@
  * ----------------------------------------------------------------------------
  */
 
-#include <cassert>
-
 #include "trackers/command_buffer.hpp"
+
 #include "framework/utils.hpp"
 #include "utils/misc.hpp"
+
+#include <cassert>
 
 namespace Tracker
 {
 
 /* See header for documentation. */
-CommandBuffer::CommandBuffer(
-    VkCommandBuffer _handle) :
-    handle(_handle)
-{
+CommandBuffer::CommandBuffer(VkCommandBuffer _handle)
+    : handle(_handle) {
 
-};
+      };
 
 /* See header for documentation. */
 void CommandBuffer::reset()
@@ -50,17 +49,14 @@ void CommandBuffer::reset()
 }
 
 /* See header for documentation. */
-void CommandBuffer::begin(
-    bool _oneTimeSubmit
-)
+void CommandBuffer::begin(bool _oneTimeSubmit)
 {
     oneTimeSubmit = _oneTimeSubmit;
 }
 
 /* See header for documentation. */
-void CommandBuffer::debugMarkerBegin(
-    std::string marker
-) {
+void CommandBuffer::debugMarkerBegin(std::string marker)
+{
     // Create a workload we can reference later
     auto workload = std::make_shared<LCSMarker>(marker);
     workloads.push_back(workload);
@@ -80,14 +76,13 @@ void CommandBuffer::debugMarkerEnd()
 }
 
 /* See header for documentation. */
-uint64_t CommandBuffer::renderPassBegin(
-    const RenderPass& renderPass,
-    uint32_t width,
-    uint32_t height,
-    bool resuming,
-    bool suspending
-) {
-    uint64_t tagID { 0 };
+uint64_t CommandBuffer::renderPassBegin(const RenderPass& renderPass,
+                                        uint32_t width,
+                                        uint32_t height,
+                                        bool resuming,
+                                        bool suspending)
+{
+    uint64_t tagID {0};
 
     assert(!currentRenderPass);
 
@@ -101,8 +96,7 @@ uint64_t CommandBuffer::renderPassBegin(
     // Populate render pass with config information
     renderPassStartDrawCount = stats.getDrawCallCount();
 
-    auto workload = std::make_shared<LCSRenderPass>(
-        tagID, renderPass, width, height, suspending, oneTimeSubmit);
+    auto workload = std::make_shared<LCSRenderPass>(tagID, renderPass, width, height, suspending, oneTimeSubmit);
 
     currentRenderPass = workload;
     workloads.push_back(workload);
@@ -132,17 +126,13 @@ bool CommandBuffer::renderPassEnd()
 }
 
 /* See header for documentation. */
-uint64_t CommandBuffer::dispatch(
-    int64_t xGroups,
-    int64_t yGroups,
-    int64_t zGroups
-) {
+uint64_t CommandBuffer::dispatch(int64_t xGroups, int64_t yGroups, int64_t zGroups)
+{
     uint64_t tagID = Tracker::LCSWorkload::assignTagID();
     stats.incDispatchCount();
 
     // Add a workload to the render pass
-    auto workload = std::make_shared<LCSDispatch>(
-        tagID, xGroups, yGroups, zGroups);
+    auto workload = std::make_shared<LCSDispatch>(tagID, xGroups, yGroups, zGroups);
     workloads.push_back(workload);
 
     // Add a command to the layer-side command stream
@@ -153,17 +143,13 @@ uint64_t CommandBuffer::dispatch(
 }
 
 /* See header for documentation. */
-uint64_t CommandBuffer::traceRays(
-    int64_t xItems,
-    int64_t yItems,
-    int64_t zItems
-) {
+uint64_t CommandBuffer::traceRays(int64_t xItems, int64_t yItems, int64_t zItems)
+{
     uint64_t tagID = Tracker::LCSWorkload::assignTagID();
     stats.incTraceRaysCount();
 
     // Add a workload to the render pass
-    auto workload = std::make_shared<LCSTraceRays>(
-        tagID, xItems, yItems, zItems);
+    auto workload = std::make_shared<LCSTraceRays>(tagID, xItems, yItems, zItems);
     workloads.push_back(workload);
 
     // Add a command to the layer-side command stream
@@ -174,16 +160,13 @@ uint64_t CommandBuffer::traceRays(
 }
 
 /* See header for documentation. */
-uint64_t CommandBuffer::imageTransfer(
-    const std::string& transferType,
-    int64_t pixelCount
-) {
+uint64_t CommandBuffer::imageTransfer(const std::string& transferType, int64_t pixelCount)
+{
     uint64_t tagID = Tracker::LCSWorkload::assignTagID();
     stats.incImageTransferCount();
 
     // Add a workload to the render pass
-    auto workload = std::make_shared<LCSImageTransfer>(
-        tagID, transferType, pixelCount);
+    auto workload = std::make_shared<LCSImageTransfer>(tagID, transferType, pixelCount);
     workloads.push_back(workload);
 
     // Add a command to the layer-side command stream
@@ -194,16 +177,13 @@ uint64_t CommandBuffer::imageTransfer(
 }
 
 /* See header for documentation. */
-uint64_t CommandBuffer::bufferTransfer(
-    const std::string& transferType,
-    int64_t byteCount
-) {
+uint64_t CommandBuffer::bufferTransfer(const std::string& transferType, int64_t byteCount)
+{
     uint64_t tagID = Tracker::LCSWorkload::assignTagID();
     stats.incBufferTransferCount();
 
     // Add a workload to the render pass
-    auto workload = std::make_shared<LCSBufferTransfer>(
-        tagID, transferType, byteCount);
+    auto workload = std::make_shared<LCSBufferTransfer>(tagID, transferType, byteCount);
     workloads.push_back(workload);
 
     // Add a command to the layer-side command stream
@@ -214,9 +194,8 @@ uint64_t CommandBuffer::bufferTransfer(
 }
 
 /* See header for documentation. */
-void CommandBuffer::executeCommands(
-    CommandBuffer& secondary
-) {
+void CommandBuffer::executeCommands(CommandBuffer& secondary)
+{
     // Integrate secondary statistics into the primary
     stats.mergeCounts(secondary.getStats());
 
@@ -226,21 +205,15 @@ void CommandBuffer::executeCommands(
 }
 
 /* See header for documentation. */
-CommandPool::CommandPool(
-    VkCommandPool _handle) :
-    handle(_handle)
-{
+CommandPool::CommandPool(VkCommandPool _handle)
+    : handle(_handle) {
 
-};
+      };
 
 /* See header for documentation. */
-CommandBuffer& CommandPool::allocateCommandBuffer(
-    VkCommandBuffer commandBuffer
-) {
-    auto result = commandBuffers.insert({
-        commandBuffer,
-        std::make_unique<CommandBuffer>(commandBuffer)
-    });
+CommandBuffer& CommandPool::allocateCommandBuffer(VkCommandBuffer commandBuffer)
+{
+    auto result = commandBuffers.insert({commandBuffer, std::make_unique<CommandBuffer>(commandBuffer)});
 
     // Validate that insertion worked
     assert(result.second);
@@ -250,9 +223,8 @@ CommandBuffer& CommandPool::allocateCommandBuffer(
 }
 
 /* See header for documentation. */
-void CommandPool::freeCommandBuffer(
-    VkCommandBuffer commandBuffer
-) {
+void CommandPool::freeCommandBuffer(VkCommandBuffer commandBuffer)
+{
     commandBuffers.erase(commandBuffer);
 }
 

--- a/source_common/trackers/command_buffer.hpp
+++ b/source_common/trackers/command_buffer.hpp
@@ -43,15 +43,16 @@
 
 #pragma once
 
+#include "trackers/layer_command_stream.hpp"
+#include "trackers/stats.hpp"
+
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
-#include <vulkan/vulkan.h>
 
-#include "trackers/stats.hpp"
-#include "trackers/layer_command_stream.hpp"
+#include <vulkan/vulkan.h>
 
 namespace Tracker
 {
@@ -67,24 +68,17 @@ public:
      *
      * @param handle   The Vulkan command buffer handle we are tracking.
      */
-    CommandBuffer(
-        VkCommandBuffer handle);
+    CommandBuffer(VkCommandBuffer handle);
 
     /**
      * @brief Get the stats object for this command buffer;
      */
-    Stats& getStats()
-    {
-        return stats;
-    }
+    Stats& getStats() { return stats; }
 
     /**
      * @brief Get the layer submit-time command stream for this command buffer.
      */
-    const std::vector<LCSInstruction>& getSubmitCommandStream() const
-    {
-        return workloadCommandStream;
-    }
+    const std::vector<LCSInstruction>& getSubmitCommandStream() const { return workloadCommandStream; }
 
     /**
      * @brief Begin recording a render pass.
@@ -98,12 +92,11 @@ public:
      * @return Returns the tagID assigned to this workload. Always returns 0
      *         if @c resuming an existing workload.
      */
-    uint64_t renderPassBegin(
-        const RenderPass& renderPass,
-        uint32_t width,
-        uint32_t height,
-        bool resuming=false,
-        bool suspending=false);
+    uint64_t renderPassBegin(const RenderPass& renderPass,
+                             uint32_t width,
+                             uint32_t height,
+                             bool resuming = false,
+                             bool suspending = false);
 
     /**
      * @brief End the current render pass workload recording.
@@ -122,10 +115,7 @@ public:
      *
      * @return Returns the tagID assigned to this workload.
      */
-    uint64_t dispatch(
-        int64_t xGroups,
-        int64_t yGroups,
-        int64_t zGroups);
+    uint64_t dispatch(int64_t xGroups, int64_t yGroups, int64_t zGroups);
 
     /**
      * @brief Capture a trace rays dispatch.
@@ -136,10 +126,7 @@ public:
      *
      * @return Returns the tagID assigned to this workload.
      */
-    uint64_t traceRays(
-        int64_t xItems,
-        int64_t yItems,
-        int64_t zItems);
+    uint64_t traceRays(int64_t xItems, int64_t yItems, int64_t zItems);
 
     /**
      * @brief Capture a transfer where the destination is an image.
@@ -149,9 +136,7 @@ public:
      *
      * @return Returns the tagID assigned to this workload.
      */
-    uint64_t imageTransfer(
-        const std::string& transferType,
-        int64_t pixelCount);
+    uint64_t imageTransfer(const std::string& transferType, int64_t pixelCount);
 
     /**
      * @brief Capture a transfer where the destination is a buffer.
@@ -161,17 +146,14 @@ public:
      *
      * @return Returns the tagID assigned to this workload.
      */
-    uint64_t bufferTransfer(
-        const std::string& transferType,
-        int64_t byteCount);
+    uint64_t bufferTransfer(const std::string& transferType, int64_t byteCount);
 
     /**
      * @brief Begin a user debug marker range.
      *
      * @param marker   The marker label.
      */
-    void debugMarkerBegin(
-        std::string marker);
+    void debugMarkerBegin(std::string marker);
 
     /**
      * @brief End a user debug marker range.
@@ -181,8 +163,7 @@ public:
     /**
      * @brief Execute a secondary command buffer.
      */
-    void executeCommands(
-        CommandBuffer& secondary);
+    void executeCommands(CommandBuffer& secondary);
 
     /**
      * @brief Reset the command buffer back into the @a Initial state.
@@ -194,8 +175,7 @@ public:
      *
      * @param oneTimeSubmit   Is this a one-time submit recording?
      */
-    void begin(
-        bool oneTimeSubmit);
+    void begin(bool oneTimeSubmit);
 
 private:
     /**
@@ -206,12 +186,12 @@ private:
     /**
      * @brief Is this command buffer recording one-time-submit?
      */
-    bool oneTimeSubmit { false };
+    bool oneTimeSubmit {false};
 
     /**
      * @brief The command buffer draw count at the start of the render pass.
      */
-    uint64_t renderPassStartDrawCount { 0 };
+    uint64_t renderPassStartDrawCount {0};
 
     /**
      * @brief The cumulative stats of the commands in this command buffer.
@@ -245,8 +225,7 @@ public:
      *
      * @param handle       The Vulkan pool buffer handle we are wrapping.
      */
-    CommandPool(
-        VkCommandPool handle);
+    CommandPool(VkCommandPool handle);
 
     /**
      * @brief Allocate a command buffer in the pool with the given handle.
@@ -255,16 +234,14 @@ public:
      *
      * \return The layer wrapper object for the command buffer.
      */
-    CommandBuffer& allocateCommandBuffer(
-        VkCommandBuffer commandBuffer);
+    CommandBuffer& allocateCommandBuffer(VkCommandBuffer commandBuffer);
 
     /**
      * @brief Free the command buffer in the pool with the given handle.
      *
      * @param commandBuffer   The Vulkan handle of the command buffer to free.
      */
-    void freeCommandBuffer(
-        VkCommandBuffer commandBuffer);
+    void freeCommandBuffer(VkCommandBuffer commandBuffer);
 
     /**
      * @brief Reset all allocated command buffers into the @a Initial state.
@@ -277,7 +254,7 @@ private:
      */
     const VkCommandPool handle;
 
-   /**
+    /**
      * @brief The command buffers currently allocated in this command pool.
      */
     std::unordered_map<VkCommandBuffer, std::unique_ptr<CommandBuffer>> commandBuffers;

--- a/source_common/trackers/device.cpp
+++ b/source_common/trackers/device.cpp
@@ -24,57 +24,45 @@
  */
 
 #include "trackers/device.hpp"
+
 #include "utils/misc.hpp"
 
 namespace Tracker
 {
 
 /* See header for documentation. */
-void Device::createCommandPool(
-    VkCommandPool commandPool
-) {
-    commandPools.insert({
-        commandPool,
-        std::make_unique<CommandPool>(commandPool)
-    });
+void Device::createCommandPool(VkCommandPool commandPool)
+{
+    commandPools.insert({commandPool, std::make_unique<CommandPool>(commandPool)});
 }
 
 /* See header for documentation. */
-CommandPool& Device::getCommandPool(
-    VkCommandPool commandPool
-) {
+CommandPool& Device::getCommandPool(VkCommandPool commandPool)
+{
     assert(isInMap(commandPool, commandPools));
     return *commandPools.at(commandPool);
 }
 
 /* See header for documentation. */
-void Device::destroyCommandPool(
-    VkCommandPool commandPool
-) {
+void Device::destroyCommandPool(VkCommandPool commandPool)
+{
     commandPools.erase(commandPool);
 }
 
 /* See header for documentation. */
-void Device::allocateCommandBuffer(
-    VkCommandPool commandPool,
-    VkCommandBuffer commandBuffer
-) {
+void Device::allocateCommandBuffer(VkCommandPool commandPool, VkCommandBuffer commandBuffer)
+{
     // Allocate in the pool
     auto& pool = getCommandPool(commandPool);
     auto& buffer = pool.allocateCommandBuffer(commandBuffer);
 
     // Insert into the tracker lookup map
-    commandBuffers.insert({
-        commandBuffer,
-        buffer
-    });
+    commandBuffers.insert({commandBuffer, buffer});
 }
 
 /* See header for documentation. */
-void Device::freeCommandBuffer(
-    VkCommandPool commandPool,
-    VkCommandBuffer commandBuffer
-) {
+void Device::freeCommandBuffer(VkCommandPool commandPool, VkCommandBuffer commandBuffer)
+{
     // Remove from the tracker lookup map
     commandBuffers.erase(commandBuffer);
 
@@ -84,74 +72,55 @@ void Device::freeCommandBuffer(
 }
 
 /* See header for documentation. */
-CommandBuffer& Device::getCommandBuffer(
-    VkCommandBuffer commandBuffer
-) {
+CommandBuffer& Device::getCommandBuffer(VkCommandBuffer commandBuffer)
+{
     assert(isInMap(commandBuffer, commandBuffers));
     return commandBuffers.at(commandBuffer);
 }
 
 /* See header for documentation. */
-void Device::createRenderPass(
-    VkRenderPass renderPass,
-    const VkRenderPassCreateInfo& createInfo
-) {
-    renderPasses.insert({
-        renderPass,
-        std::make_unique<RenderPass>(renderPass, createInfo)
-    });
+void Device::createRenderPass(VkRenderPass renderPass, const VkRenderPassCreateInfo& createInfo)
+{
+    renderPasses.insert({renderPass, std::make_unique<RenderPass>(renderPass, createInfo)});
 }
 
 /* See header for documentation. */
-void Device::createRenderPass(
-    VkRenderPass renderPass,
-    const VkRenderPassCreateInfo2& createInfo
-) {
-    renderPasses.insert({
-        renderPass,
-        std::make_unique<RenderPass>(renderPass, createInfo)
-    });
+void Device::createRenderPass(VkRenderPass renderPass, const VkRenderPassCreateInfo2& createInfo)
+{
+    renderPasses.insert({renderPass, std::make_unique<RenderPass>(renderPass, createInfo)});
 }
 
 /* See header for documentation. */
-RenderPass& Device::getRenderPass(
-    VkRenderPass renderPass
-) {
+RenderPass& Device::getRenderPass(VkRenderPass renderPass)
+{
     assert(isInMap(renderPass, renderPasses));
     return *renderPasses.at(renderPass);
 }
 
 /* See header for documentation. */
-void Device::destroyRenderPass(
-    VkRenderPass renderPass
-) {
+void Device::destroyRenderPass(VkRenderPass renderPass)
+{
     renderPasses.erase(renderPass);
 }
 
 /* See header for documentation. */
-Queue& Device::getQueue(
-    VkQueue queue
-) {
+Queue& Device::getQueue(VkQueue queue)
+{
     // Create a tracker for a queue on first use
     if (!isInMap(queue, queues))
     {
-        queues.insert({
-            queue,
-            std::make_unique<Queue>(queue)
-        });
+        queues.insert({queue, std::make_unique<Queue>(queue)});
     }
 
     return *queues.at(queue);
 }
 
 /* See header for documentation. */
-void Device::queueSubmit(
-    VkCommandBuffer commandBuffer
-) {
+void Device::queueSubmit(VkCommandBuffer commandBuffer)
+{
     auto& cbStats = getCommandBuffer(commandBuffer).getStats();
     frameStats.mergeCounts(cbStats);
 }
-
 
 /* See header for documentation. */
 void Device::queuePresent()

--- a/source_common/trackers/device.hpp
+++ b/source_common/trackers/device.hpp
@@ -38,12 +38,13 @@
 
 #pragma once
 
-#include <unordered_map>
-#include <vulkan/vulkan.h>
-
 #include "trackers/command_buffer.hpp"
 #include "trackers/queue.hpp"
 #include "trackers/render_pass.hpp"
+
+#include <unordered_map>
+
+#include <vulkan/vulkan.h>
 
 namespace Tracker
 {
@@ -59,16 +60,14 @@ public:
      *
      * @param commandPool   The native handle to track.
      */
-    void createCommandPool(
-        VkCommandPool commandPool);
+    void createCommandPool(VkCommandPool commandPool);
 
     /**
      * @brief Get the tracker for a native command pool.
      *
      * @param commandPool   The native handle we are tracking.
      */
-    CommandPool& getCommandPool(
-        VkCommandPool commandPool);
+    CommandPool& getCommandPool(VkCommandPool commandPool);
 
     /**
      * @brief Create a new command buffer in a pool within this device.
@@ -76,9 +75,7 @@ public:
      * @param commandPool     The native parent command pool handle.
      * @param commandBuffer   The native handle to track.
      */
-    void allocateCommandBuffer(
-        VkCommandPool commandPool,
-        VkCommandBuffer commandBuffer);
+    void allocateCommandBuffer(VkCommandPool commandPool, VkCommandBuffer commandBuffer);
 
     /**
      * @brief Free a command buffer in a pool within this device.
@@ -86,25 +83,21 @@ public:
      * @param commandPool     The native parent command pool handle.
      * @param commandBuffer   The native handle to stop tracking.
      */
-    void freeCommandBuffer(
-        VkCommandPool commandPool,
-        VkCommandBuffer commandBuffer);
+    void freeCommandBuffer(VkCommandPool commandPool, VkCommandBuffer commandBuffer);
 
     /**
      * @brief Get the tracker for native command buffer.
      *
      * @param commandBuffer   The native handle we are tracking.
      */
-    CommandBuffer& getCommandBuffer(
-        VkCommandBuffer commandBuffer);
+    CommandBuffer& getCommandBuffer(VkCommandBuffer commandBuffer);
 
     /**
      * @brief Destroy a command pool within this device.
      *
      * @param commandPool   The native handle to stop tracking.
      */
-    void destroyCommandPool(
-        VkCommandPool commandPool);
+    void destroyCommandPool(VkCommandPool commandPool);
 
     /**
      * @brief Get the tracker for a native queue.
@@ -114,8 +107,7 @@ public:
      *
      * @param queue   The native handle we are tracking.
      */
-    Queue& getQueue(
-        VkQueue queue);
+    Queue& getQueue(VkQueue queue);
 
     /**
      * @brief Create a new render pass tracker within this device.
@@ -123,9 +115,7 @@ public:
      * @param renderPass   The native handle to track.
      * @param createInfo   The render pass configuration information.
      */
-    void createRenderPass(
-        VkRenderPass renderPass,
-        const VkRenderPassCreateInfo& createInfo);
+    void createRenderPass(VkRenderPass renderPass, const VkRenderPassCreateInfo& createInfo);
 
     /**
      * @brief Create a new render pass tracker within this device.
@@ -133,33 +123,28 @@ public:
      * @param renderPass   The native handle to track.
      * @param createInfo   The render pass configuration information.
      */
-    void createRenderPass(
-        VkRenderPass renderPass,
-        const VkRenderPassCreateInfo2& createInfo);
+    void createRenderPass(VkRenderPass renderPass, const VkRenderPassCreateInfo2& createInfo);
 
     /**
      * @brief Get the tracker for a native render pass.
      *
      * @param renderPass   The native handle we are tracking.
      */
-    RenderPass& getRenderPass(
-        VkRenderPass renderPass);
+    RenderPass& getRenderPass(VkRenderPass renderPass);
 
     /**
      * @brief Destroy a render pass within this device.
      *
      * @param renderPass   The native handle to stop tracking.
      */
-    void destroyRenderPass(
-        VkRenderPass renderPass);
+    void destroyRenderPass(VkRenderPass renderPass);
 
     /**
      * @brief Submit a command buffer to a queue within this device.
      *
      * @param commandBuffer   The native command buffer we are tracking.
      */
-    void queueSubmit(
-        VkCommandBuffer commandBuffer);
+    void queueSubmit(VkCommandBuffer commandBuffer);
 
     /**
      * @brief Submit a display present command to a queue within this device.

--- a/source_common/trackers/layer_command_stream.cpp
+++ b/source_common/trackers/layer_command_stream.cpp
@@ -23,50 +23,43 @@
  * ----------------------------------------------------------------------------
  */
 
-#include <cassert>
-#include <nlohmann/json.hpp>
-
 #include "trackers/layer_command_stream.hpp"
+
+#include <cassert>
+
+#include <nlohmann/json.hpp>
 
 using json = nlohmann::json;
 
 namespace Tracker
 {
 /* See header for details. */
-std::atomic<uint64_t> LCSWorkload::nextTagID { 1 };
+std::atomic<uint64_t> LCSWorkload::nextTagID {1};
 
-LCSWorkload::LCSWorkload(
-    uint64_t _tagID
-):
-    tagID(_tagID)
+LCSWorkload::LCSWorkload(uint64_t _tagID)
+    : tagID(_tagID)
 {
-
 }
 
 /* See header for details. */
-LCSMarker::LCSMarker(
-    const std::string& _label
-) :
-    LCSWorkload(0),
-    label(_label)
-{
+LCSMarker::LCSMarker(const std::string& _label)
+    : LCSWorkload(0),
+      label(_label) {
 
-};
+      };
 
 /* See header for details. */
-LCSRenderPass::LCSRenderPass(
-    uint64_t _tagID,
-    const RenderPass& renderPass,
-    uint32_t _width,
-    uint32_t _height,
-    bool _suspending,
-    bool _oneTimeSubmit
-) :
-    LCSWorkload(_tagID),
-    width(_width),
-    height(_height),
-    suspending(_suspending),
-    oneTimeSubmit(_oneTimeSubmit)
+LCSRenderPass::LCSRenderPass(uint64_t _tagID,
+                             const RenderPass& renderPass,
+                             uint32_t _width,
+                             uint32_t _height,
+                             bool _suspending,
+                             bool _oneTimeSubmit)
+    : LCSWorkload(_tagID),
+      width(_width),
+      height(_height),
+      suspending(_suspending),
+      oneTimeSubmit(_oneTimeSubmit)
 {
     // Copy these as the render pass object may be transient.
     subpassCount = renderPass.getSubpassCount();
@@ -74,8 +67,7 @@ LCSRenderPass::LCSRenderPass(
 }
 
 /* See header for details. */
-std::string LCSRenderPass::getBeginMetadata(
-     const std::vector<std::string>* debugLabel) const
+std::string LCSRenderPass::getBeginMetadata(const std::vector<std::string>* debugLabel) const
 {
     // Draw count for a multi-submit command buffer cannot be reliably
     // associated with a single tagID if restartable across command buffer
@@ -88,11 +80,11 @@ std::string LCSRenderPass::getBeginMetadata(
     }
 
     json metadata = {
-        { "type", "renderpass" },
-        { "tid", tagID },
-        { "width", width },
-        { "height", height },
-        { "drawCallCount", drawCount }
+        {"type", "renderpass"},
+        {"tid", tagID},
+        {"width", width},
+        {"height", height},
+        {"drawCallCount", drawCount},
     };
 
     if (debugLabel && debugLabel->size())
@@ -110,7 +102,7 @@ std::string LCSRenderPass::getBeginMetadata(
     for (const auto& attachment : attachments)
     {
         json attachPoint {
-            { "binding", attachment.getAttachmentStr() },
+            {"binding", attachment.getAttachmentStr()},
         };
 
         // Default is false, so only serialize if we need it
@@ -139,14 +131,13 @@ std::string LCSRenderPass::getBeginMetadata(
 }
 
 /* See header for details. */
-std::string LCSRenderPass::getContinuationMetadata(
-    const std::vector<std::string>* debugLabel,
-    uint64_t tagIDContinuation) const
+std::string LCSRenderPass::getContinuationMetadata(const std::vector<std::string>* debugLabel,
+                                                   uint64_t tagIDContinuation) const
 {
     json metadata = {
-        { "type", "renderpass" },
-        { "tid", tagIDContinuation },
-        { "drawCallCount", drawCallCount }
+        {"type", "renderpass"},
+        {"tid", tagIDContinuation},
+        {"drawCallCount", drawCallCount},
     };
 
     if (debugLabel && debugLabel->size())
@@ -158,9 +149,7 @@ std::string LCSRenderPass::getContinuationMetadata(
 }
 
 /* See header for details. */
-std::string LCSRenderPass::getMetadata(
-    const std::vector<std::string>* debugLabel,
-    uint64_t tagIDContinuation) const
+std::string LCSRenderPass::getMetadata(const std::vector<std::string>* debugLabel, uint64_t tagIDContinuation) const
 {
     if (tagID)
     {
@@ -173,33 +162,25 @@ std::string LCSRenderPass::getMetadata(
 }
 
 /* See header for details. */
-LCSDispatch::LCSDispatch(
-    uint64_t _tagID,
-    int64_t _xGroups,
-    int64_t _yGroups,
-    int64_t _zGroups
-) :
-    LCSWorkload(_tagID),
-    xGroups(_xGroups),
-    yGroups(_yGroups),
-    zGroups(_zGroups)
+LCSDispatch::LCSDispatch(uint64_t _tagID, int64_t _xGroups, int64_t _yGroups, int64_t _zGroups)
+    : LCSWorkload(_tagID),
+      xGroups(_xGroups),
+      yGroups(_yGroups),
+      zGroups(_zGroups)
 {
-
 }
 
 /* See header for details. */
-std::string LCSDispatch::getMetadata(
-    const std::vector<std::string>* debugLabel,
-    uint64_t tagIDContinuation
-) const {
+std::string LCSDispatch::getMetadata(const std::vector<std::string>* debugLabel, uint64_t tagIDContinuation) const
+{
     UNUSED(tagIDContinuation);
 
     json metadata = {
-        { "type", "dispatch" },
-        { "tid", tagID },
-        { "xGroups", xGroups },
-        { "yGroups", yGroups },
-        { "zGroups", zGroups }
+        {"type", "dispatch"},
+        {"tid", tagID},
+        {"xGroups", xGroups},
+        {"yGroups", yGroups},
+        {"zGroups", zGroups},
     };
 
     if (debugLabel && debugLabel->size())
@@ -211,33 +192,25 @@ std::string LCSDispatch::getMetadata(
 }
 
 /* See header for details. */
-LCSTraceRays::LCSTraceRays(
-    uint64_t _tagID,
-    int64_t _xItems,
-    int64_t _yItems,
-    int64_t _zItems
-) :
-    LCSWorkload(_tagID),
-    xItems(_xItems),
-    yItems(_yItems),
-    zItems(_zItems)
+LCSTraceRays::LCSTraceRays(uint64_t _tagID, int64_t _xItems, int64_t _yItems, int64_t _zItems)
+    : LCSWorkload(_tagID),
+      xItems(_xItems),
+      yItems(_yItems),
+      zItems(_zItems)
 {
-
 }
 
 /* See header for details. */
-std::string LCSTraceRays::getMetadata(
-    const std::vector<std::string>* debugLabel,
-    uint64_t tagIDContinuation
-) const {
+std::string LCSTraceRays::getMetadata(const std::vector<std::string>* debugLabel, uint64_t tagIDContinuation) const
+{
     UNUSED(tagIDContinuation);
 
     json metadata = {
-        { "type", "tracerays" },
-        { "tid", tagID },
-        { "xItems", xItems },
-        { "yItems", yItems },
-        { "zItems", zItems }
+        {"type", "tracerays"},
+        {"tid", tagID},
+        {"xItems", xItems},
+        {"yItems", yItems},
+        {"zItems", zItems},
     };
 
     if (debugLabel && debugLabel->size())
@@ -249,31 +222,23 @@ std::string LCSTraceRays::getMetadata(
 }
 
 /* See header for details. */
-LCSImageTransfer::LCSImageTransfer(
-    uint64_t _tagID,
-    const std::string& _transferType,
-    int64_t _pixelCount
-):
-    LCSWorkload(_tagID),
-    transferType(_transferType),
-    pixelCount(_pixelCount)
+LCSImageTransfer::LCSImageTransfer(uint64_t _tagID, const std::string& _transferType, int64_t _pixelCount)
+    : LCSWorkload(_tagID),
+      transferType(_transferType),
+      pixelCount(_pixelCount)
 {
-
 }
 
 /* See header for details. */
-std::string LCSImageTransfer::getMetadata(
-    const std::vector<std::string>* debugLabel,
-    uint64_t tagIDContinuation
-) const
+std::string LCSImageTransfer::getMetadata(const std::vector<std::string>* debugLabel, uint64_t tagIDContinuation) const
 {
     UNUSED(tagIDContinuation);
 
     json metadata = {
-        { "type", "imagetransfer" },
-        { "tid", tagID },
-        { "subtype", transferType },
-        { "pixelCount", pixelCount }
+        {"type", "imagetransfer"},
+        {"tid", tagID},
+        {"subtype", transferType},
+        {"pixelCount", pixelCount},
     };
 
     if (debugLabel && debugLabel->size())
@@ -285,30 +250,23 @@ std::string LCSImageTransfer::getMetadata(
 }
 
 /* See header for details. */
-LCSBufferTransfer::LCSBufferTransfer(
-    uint64_t _tagID,
-    const std::string& _transferType,
-    int64_t _byteCount
-):
-    LCSWorkload(_tagID),
-    transferType(_transferType),
-    byteCount(_byteCount)
+LCSBufferTransfer::LCSBufferTransfer(uint64_t _tagID, const std::string& _transferType, int64_t _byteCount)
+    : LCSWorkload(_tagID),
+      transferType(_transferType),
+      byteCount(_byteCount)
 {
-
 }
 
 /* See header for details. */
-std::string LCSBufferTransfer::getMetadata(
-    const std::vector<std::string>* debugLabel,
-    uint64_t tagIDContinuation
-) const {
+std::string LCSBufferTransfer::getMetadata(const std::vector<std::string>* debugLabel, uint64_t tagIDContinuation) const
+{
     UNUSED(tagIDContinuation);
 
     json metadata = {
-        { "type", "buffertransfer" },
-        { "tid", tagID },
-        { "subtype", transferType },
-        { "byteCount", byteCount }
+        {"type", "buffertransfer"},
+        {"tid", tagID},
+        {"subtype", transferType},
+        {"byteCount", byteCount},
     };
 
     if (debugLabel && debugLabel->size())

--- a/source_common/trackers/layer_command_stream.hpp
+++ b/source_common/trackers/layer_command_stream.hpp
@@ -38,15 +38,16 @@
 
 #pragma once
 
+#include "trackers/render_pass.hpp"
+#include "utils/misc.hpp"
+
 #include <atomic>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
-#include <vulkan/vulkan.h>
 
-#include "trackers/render_pass.hpp"
-#include "utils/misc.hpp"
+#include <vulkan/vulkan.h>
 
 namespace Tracker
 {
@@ -76,8 +77,7 @@ public:
      *
      * @param tagID   The assigned tagID.
      */
-    LCSWorkload(
-        uint64_t tagID);
+    LCSWorkload(uint64_t tagID);
 
     /**
      * @brief Destroy a workload.
@@ -90,29 +90,22 @@ public:
      * @param debugLabel          The debug label stack for the VkQueue at submit time.
      * @param tagIDContinuation   The ID of the workload if this is a continuation of it.
      */
-    virtual std::string getMetadata(
-        const std::vector<std::string>* debugLabel=nullptr,
-        uint64_t tagIDContinuation=0) const = 0;
+    virtual std::string getMetadata(const std::vector<std::string>* debugLabel = nullptr,
+                                    uint64_t tagIDContinuation = 0) const = 0;
 
     /**
      * @brief Get this workload's tagID.
      *
      * @return The assigned ID.
      */
-    uint64_t getTagID() const
-    {
-        return tagID;
-    }
+    uint64_t getTagID() const { return tagID; }
 
     /**
      * @brief Get a unique tagID to label a workload in a command buffer.
      *
      * @return The assigned ID.
      */
-    static uint64_t assignTagID()
-    {
-        return nextTagID.fetch_add(1, std::memory_order_relaxed);
-    }
+    static uint64_t assignTagID() { return nextTagID.fetch_add(1, std::memory_order_relaxed); }
 
 protected:
     /**
@@ -145,13 +138,12 @@ public:
      * @param suspending      Is this a render pass part that suspends later?
      * @param oneTimeSubmit   Is this recorded into a one-time-submit command buffer?
      */
-    LCSRenderPass(
-        uint64_t tagID,
-        const RenderPass& renderPass,
-        uint32_t width,
-        uint32_t height,
-        bool suspending,
-        bool oneTimeSubmit);
+    LCSRenderPass(uint64_t tagID,
+                  const RenderPass& renderPass,
+                  uint32_t width,
+                  uint32_t height,
+                  bool suspending,
+                  bool oneTimeSubmit);
 
     /**
      * @brief Destroy a workload.
@@ -163,25 +155,18 @@ public:
      *
      * @return @c true if this instance suspends rather than ends.
      */
-    bool isSuspending() const
-    {
-        return suspending;
-    };
+    bool isSuspending() const { return suspending; };
 
     /**
      * @brief Update this workload with the final draw count.
      *
      * @param count   The number of draw calls tracked by the command buffer.
      */
-    void setDrawCallCount(uint64_t count)
-    {
-        drawCallCount = count;
-    };
+    void setDrawCallCount(uint64_t count) { drawCallCount = count; };
 
     /* See base class for documentation. */
-    virtual std::string getMetadata(
-        const std::vector<std::string>* debugLabel=nullptr,
-        uint64_t tagIDContinuation=0) const;
+    virtual std::string getMetadata(const std::vector<std::string>* debugLabel = nullptr,
+                                    uint64_t tagIDContinuation = 0) const;
 
 private:
     /**
@@ -189,8 +174,7 @@ private:
      *
      * @param debugLabel   The debug label stack of the VkQueue at submit time.
      */
-    std::string getBeginMetadata(
-        const std::vector<std::string>* debugLabel=nullptr) const;
+    std::string getBeginMetadata(const std::vector<std::string>* debugLabel = nullptr) const;
 
     /**
      * @brief Get the metadata for this workload if continuing an existing render pass.
@@ -198,9 +182,8 @@ private:
      * @param debugLabel          The debug label stack of the VkQueue at submit time.
      * @param tagIDContinuation   The ID of the workload if this is a continuation of it.
      */
-    std::string getContinuationMetadata(
-        const std::vector<std::string>* debugLabel=nullptr,
-        uint64_t tagIDContinuation=0) const;
+    std::string getContinuationMetadata(const std::vector<std::string>* debugLabel = nullptr,
+                                        uint64_t tagIDContinuation = 0) const;
 
     /**
      * @brief Width of this workload, in pixels.
@@ -233,7 +216,7 @@ private:
      * Note: This is updated by ther command buffer tracker when the render
      * pass is suspended or ended.
      */
-    uint64_t drawCallCount { 0 };
+    uint64_t drawCallCount {0};
 
     /**
      * @brief The attachments for this render pass.
@@ -257,11 +240,7 @@ public:
      * @param yGroups   The number of work groups in the Y dimension.
      * @param zGroups   The number of work groups in the Z dimension.
      */
-    LCSDispatch(
-        uint64_t tagID,
-        int64_t xGroups,
-        int64_t yGroups,
-        int64_t zGroups);
+    LCSDispatch(uint64_t tagID, int64_t xGroups, int64_t yGroups, int64_t zGroups);
 
     /**
      * @brief Destroy a workload.
@@ -269,9 +248,8 @@ public:
     virtual ~LCSDispatch() = default;
 
     /* See base class for documentation. */
-    virtual std::string getMetadata(
-        const std::vector<std::string>* debugLabel=nullptr,
-        uint64_t tagIDContinuation=0) const;
+    virtual std::string getMetadata(const std::vector<std::string>* debugLabel = nullptr,
+                                    uint64_t tagIDContinuation = 0) const;
 
 private:
     /**
@@ -306,11 +284,7 @@ public:
      * @param yItems   The number of work items in the Y dimension.
      * @param zItems   The number of work items in the Z dimension.
      */
-    LCSTraceRays(
-        uint64_t tagID,
-        int64_t xItems,
-        int64_t yItems,
-        int64_t zItems);
+    LCSTraceRays(uint64_t tagID, int64_t xItems, int64_t yItems, int64_t zItems);
 
     /**
      * @brief Destroy a workload.
@@ -318,9 +292,8 @@ public:
     virtual ~LCSTraceRays() = default;
 
     /* See base class for documentation. */
-    virtual std::string getMetadata(
-        const std::vector<std::string>* debugLabel=nullptr,
-        uint64_t tagIDContinuation=0) const;
+    virtual std::string getMetadata(const std::vector<std::string>* debugLabel = nullptr,
+                                    uint64_t tagIDContinuation = 0) const;
 
 private:
     /**
@@ -354,10 +327,7 @@ public:
      * @param transferType   The subtype of the transfer.
      * @param pixelCount     The size of the transfer, in pixels.
      */
-    LCSImageTransfer(
-        uint64_t tagID,
-        const std::string& transferType,
-        int64_t pixelCount);
+    LCSImageTransfer(uint64_t tagID, const std::string& transferType, int64_t pixelCount);
 
     /**
      * @brief Destroy a workload.
@@ -365,9 +335,8 @@ public:
     virtual ~LCSImageTransfer() = default;
 
     /* See base class for documentation. */
-    virtual std::string getMetadata(
-        const std::vector<std::string>* debugLabel=nullptr,
-        uint64_t tagIDContinuation=0) const;
+    virtual std::string getMetadata(const std::vector<std::string>* debugLabel = nullptr,
+                                    uint64_t tagIDContinuation = 0) const;
 
 private:
     /**
@@ -397,10 +366,7 @@ public:
      * @param transferType   The subtype of the transfer.
      * @param byteCount      The size of the transfer, in bytes.
      */
-    LCSBufferTransfer(
-        uint64_t tagID,
-        const std::string& transferType,
-        int64_t byteCount);
+    LCSBufferTransfer(uint64_t tagID, const std::string& transferType, int64_t byteCount);
 
     /**
      * @brief Destroy a workload.
@@ -408,9 +374,8 @@ public:
     virtual ~LCSBufferTransfer() = default;
 
     /* See base class for documentation. */
-    virtual std::string getMetadata(
-        const std::vector<std::string>* debugLabel=nullptr,
-        uint64_t tagIDContinuation=0) const;
+    virtual std::string getMetadata(const std::vector<std::string>* debugLabel = nullptr,
+                                    uint64_t tagIDContinuation = 0) const;
 
 private:
     /**
@@ -438,8 +403,7 @@ public:
      *
      * @param label   The application debug label.
      */
-    LCSMarker(
-        const std::string& label);
+    LCSMarker(const std::string& label);
 
     /**
      * @brief Destroy a workload.
@@ -447,9 +411,8 @@ public:
     virtual ~LCSMarker() = default;
 
     /* See base class for documentation. */
-    virtual std::string getMetadata(
-        const std::vector<std::string>* debugLabel=nullptr,
-        uint64_t tagIDContinuation=0) const
+    virtual std::string getMetadata(const std::vector<std::string>* debugLabel = nullptr,
+                                    uint64_t tagIDContinuation = 0) const
     {
         UNUSED(debugLabel);
         UNUSED(tagIDContinuation);

--- a/source_common/trackers/queue.cpp
+++ b/source_common/trackers/queue.cpp
@@ -23,27 +23,23 @@
  * ----------------------------------------------------------------------------
  */
 
-#include <cassert>
-
 #include "trackers/queue.hpp"
+
+#include <cassert>
 
 namespace Tracker
 {
 /* See header for details. */
-Queue::Queue(
-    VkQueue _handle
-):
-    handle(_handle)
-{
+Queue::Queue(VkQueue _handle)
+    : handle(_handle) {
 
-};
+      };
 
 /* See header for details. */
-void Queue::runSubmitCommandStream(
-    const std::vector<LCSInstruction>& stream,
-    std::function<void(const std::string&)> callback
-) {
-    for (auto& instr: stream)
+void Queue::runSubmitCommandStream(const std::vector<LCSInstruction>& stream,
+                                   std::function<void(const std::string&)> callback)
+{
+    for (auto& instr : stream)
     {
         LCSOpcode opCode = instr.first;
         const LCSWorkload* opData = instr.second.get();
@@ -84,10 +80,8 @@ void Queue::runSubmitCommandStream(
                 }
             }
         }
-        else if ((opCode == LCSOpcode::DISPATCH) ||
-                 (opCode == LCSOpcode::TRACE_RAYS) ||
-                 (opCode == LCSOpcode::IMAGE_TRANSFER) ||
-                 (opCode == LCSOpcode::BUFFER_TRANSFER))
+        else if ((opCode == LCSOpcode::DISPATCH) || (opCode == LCSOpcode::TRACE_RAYS)
+                 || (opCode == LCSOpcode::IMAGE_TRANSFER) || (opCode == LCSOpcode::BUFFER_TRANSFER))
         {
             uint64_t tagID = opData->getTagID();
             std::string log = joinString(debugStack, "|");

--- a/source_common/trackers/queue.hpp
+++ b/source_common/trackers/queue.hpp
@@ -41,14 +41,15 @@
 
 #pragma once
 
+#include "framework/utils.hpp"
+#include "trackers/layer_command_stream.hpp"
+
 #include <atomic>
 #include <functional>
 #include <string>
 #include <vector>
-#include <vulkan/vulkan.h>
 
-#include "framework/utils.hpp"
-#include "trackers/layer_command_stream.hpp"
+#include <vulkan/vulkan.h>
 
 namespace Tracker
 {
@@ -59,8 +60,7 @@ namespace Tracker
 class Queue
 {
 public:
-    Queue(
-        VkQueue handle);
+    Queue(VkQueue handle);
 
     /**
      * @brief Execute a layer command stream.
@@ -68,9 +68,8 @@ public:
      * @param stream     The layer command stream to execute.
      * @param callback   The callback to pass submitted workloads to.
      */
-    void runSubmitCommandStream(
-        const std::vector<LCSInstruction>& stream,
-        std::function<void(const std::string&)> callback);
+    void runSubmitCommandStream(const std::vector<LCSInstruction>& stream,
+                                std::function<void(const std::string&)> callback);
 
 private:
     /**
@@ -86,7 +85,7 @@ private:
     /**
      * @brief The last non-zero render pass tagID submitted.
      */
-    uint64_t lastRenderPassTagID { 0 };
+    uint64_t lastRenderPassTagID {0};
 };
 
 }

--- a/source_common/trackers/render_pass.hpp
+++ b/source_common/trackers/render_pass.hpp
@@ -38,6 +38,7 @@
 #include <cassert>
 #include <string>
 #include <vector>
+
 #include <vulkan/vulkan.h>
 
 namespace Tracker
@@ -74,11 +75,10 @@ public:
      * @param storeOp   The render pass storeOp for this attachment.
      * @param resolve   Is this a resolve attachment or the main attachment?
      */
-    RenderPassAttachment(
-        RenderPassAttachName name,
-        VkAttachmentLoadOp loadOp,
-        VkAttachmentStoreOp storeOp,
-        bool resolve);
+    RenderPassAttachment(RenderPassAttachName name,
+                         VkAttachmentLoadOp loadOp,
+                         VkAttachmentStoreOp storeOp,
+                         bool resolve);
 
     /**
      * @brief Get a string form of the attachment point name.
@@ -92,21 +92,14 @@ public:
      *
      * @return @c true if loaded from memory.
      */
-    bool isLoaded() const
-    {
-        return loadOp == VK_ATTACHMENT_LOAD_OP_LOAD;
-    }
+    bool isLoaded() const { return loadOp == VK_ATTACHMENT_LOAD_OP_LOAD; }
 
     /**
      * @brief Is this attachment stored at the end of the render pass?
      *
      * @return @c true if stored to memory.
      */
-    bool isStored() const
-    {
-        return storeOp == VK_ATTACHMENT_STORE_OP_STORE;
-    }
-
+    bool isStored() const { return storeOp == VK_ATTACHMENT_STORE_OP_STORE; }
 
     /**
      * @brief Is this attachment a resolve attachment?
@@ -116,10 +109,7 @@ public:
      *
      * @return @c true if this is a resolve attachment.
      */
-    bool isResolved() const
-    {
-        return resolve;
-    }
+    bool isResolved() const { return resolve; }
 
 private:
     /**
@@ -155,9 +145,7 @@ public:
      * @param handle       The driver handle of the render pass.
      * @param createInfo   The API context creating the render pass.
      */
-    RenderPass(
-        VkRenderPass handle,
-        const VkRenderPassCreateInfo& createInfo);
+    RenderPass(VkRenderPass handle, const VkRenderPassCreateInfo& createInfo);
 
     /**
      * @brief Construct a new render pass from Vulkan 1.0-style render passes.
@@ -165,17 +153,14 @@ public:
      * @param handle       The driver handle of the render pass.
      * @param createInfo   The API context creating the render pass.
      */
-    RenderPass(
-        VkRenderPass handle,
-        const VkRenderPassCreateInfo2& createInfo);
+    RenderPass(VkRenderPass handle, const VkRenderPassCreateInfo2& createInfo);
 
     /**
      * @brief Construct a new render pass from Vulkan 1.3 dynamic rendering.
      *
      * @param createInfo   The API context starting the render pass.
      */
-    RenderPass(
-        const VkRenderingInfo& createInfo);
+    RenderPass(const VkRenderingInfo& createInfo);
 
     /**
      * @brief Get the number of subpasses in the render pass.
@@ -183,18 +168,12 @@ public:
      * @return The number of subpasses. Always returns 1 for dynamic render
      *         passes which no longer use subpasses.
      */
-    uint32_t getSubpassCount() const
-    {
-        return subpassCount;
-    };
+    uint32_t getSubpassCount() const { return subpassCount; };
 
     /**
      * @brief Get the attachment list for the render pass.
      */
-    const std::vector<RenderPassAttachment>& getAttachments() const
-    {
-        return attachments;
-    };
+    const std::vector<RenderPassAttachment>& getAttachments() const { return attachments; };
 
 private:
     /**
@@ -205,7 +184,7 @@ private:
     /**
      * @brief The render pass subpass count.
      */
-    uint32_t subpassCount { 1 };
+    uint32_t subpassCount {1};
 
     /**
      * @brief The render pass attachments in this render pass.

--- a/source_common/trackers/stats.hpp
+++ b/source_common/trackers/stats.hpp
@@ -32,6 +32,7 @@
 
 #include <cstdint>
 #include <unordered_map>
+
 #include <vulkan/vulkan.h>
 
 namespace Tracker
@@ -50,58 +51,37 @@ public:
     /**
      * @brief Increment the frame counter.
      */
-    void incFrameCount()
-    {
-        frameCount += 1;
-    }
+    void incFrameCount() { frameCount += 1; }
 
     /**
      * @brief Increment the render pass counter.
      */
-    void incRenderPassCount()
-    {
-        renderPassCount += 1;
-    }
+    void incRenderPassCount() { renderPassCount += 1; }
 
     /**
      * @brief Increment the draw counter.
      */
-    void incDrawCallCount()
-    {
-        drawCallCount += 1;
-    }
+    void incDrawCallCount() { drawCallCount += 1; }
 
     /**
      * @brief Increment the compute dispatch counter.
      */
-    void incDispatchCount()
-    {
-        dispatchCount += 1;
-    }
+    void incDispatchCount() { dispatchCount += 1; }
 
     /**
      * @brief Increment the trace rays counter.
      */
-    void incTraceRaysCount()
-    {
-        traceRaysCount += 1;
-    };
+    void incTraceRaysCount() { traceRaysCount += 1; };
 
     /**
      * @brief Increment the buffer transfer counter.
      */
-    void incBufferTransferCount()
-    {
-        bufferTransferCount += 1;
-    }
+    void incBufferTransferCount() { bufferTransferCount += 1; }
 
     /**
      * @brief Increment the image transfer counter.
      */
-    void incImageTransferCount()
-    {
-        imageTransferCount += 1;
-    }
+    void incImageTransferCount() { imageTransferCount += 1; }
 
     /**
      * @brief Increment all counters with values from another stats object.
@@ -134,94 +114,77 @@ public:
     /**
      * @brief Get the frame counter.
      */
-    uint64_t getFrameCount() const
-    {
-        return frameCount;
-    }
+    uint64_t getFrameCount() const { return frameCount; }
 
     /**
      * @brief Increment the render pass counter.
      */
-    uint64_t getRenderPassCount() const
-    {
-        return renderPassCount;
-    }
+    uint64_t getRenderPassCount() const { return renderPassCount; }
 
     /**
      * @brief Increment the draw counter.
      */
-    uint64_t getDrawCallCount() const
-    {
-        return drawCallCount;
-    }
+    uint64_t getDrawCallCount() const { return drawCallCount; }
 
     /**
      * @brief Increment the compute dispatch counter.
      */
-    uint64_t getDispatchCount() const
-    {
-        return dispatchCount;
-    }
+    uint64_t getDispatchCount() const { return dispatchCount; }
 
     /**
      * @brief Increment the trace rays counter.
      */
-    uint64_t getTraceRaysCount() const
-    {
-        return traceRaysCount;
-    };
+    uint64_t getTraceRaysCount() const { return traceRaysCount; };
 
     /**
      * @brief Increment the buffer transfer counter.
      */
-    uint64_t getBufferTransferCount() const
-    {
-        return bufferTransferCount;
-    }
+    uint64_t getBufferTransferCount() const { return bufferTransferCount; }
 
     /**
      * @brief Increment the image transfer counter.
      */
     uint64_t getImageTransferCount() const
     {
-        return imageTransferCount;;
+        return imageTransferCount;
+        ;
     }
 
 private:
     /**
      * @brief The number of frames tracked.
      */
-    uint64_t frameCount { 0 };
+    uint64_t frameCount {0};
 
     /**
      * @brief The number of render passes tracked.
      */
-    uint64_t renderPassCount { 0 };
+    uint64_t renderPassCount {0};
 
     /**
      * @brief The number of draw calls tracked.
      */
-    uint64_t drawCallCount { 0 };
+    uint64_t drawCallCount {0};
 
     /**
      * @brief The number of compute dispatches tracked.
      */
-    uint64_t dispatchCount { 0 };
+    uint64_t dispatchCount {0};
 
     /**
      * @brief The number of trace rays calls tracked.
      */
-    uint64_t traceRaysCount { 0 };
+    uint64_t traceRaysCount {0};
 
     /**
      * @brief The number of buffer transfers tracked.
      */
-    uint64_t bufferTransferCount { 0 };
+    uint64_t bufferTransferCount {0};
 
     /**
      * @brief The number of image transfers tracked.
      */
-    uint64_t imageTransferCount { 0 };
+    uint64_t imageTransferCount {0};
 };
 
 }


### PR DESCRIPTION
Additionally, the .clang-format file can be picked up by various IDEs to ensure consistent formatting.

The .clang-format tries to align as much as is possible with the existing formatting, though some differences can be noted, particularly around method parameters in declarations.