### PR TITLE
Swap to manifest.json for install config

### DIFF
--- a/generator/generate_vulkan_layer.py
+++ b/generator/generate_vulkan_layer.py
@@ -125,16 +125,16 @@ def generate_source_cmake(file: TextIO, vendor: str, layer: str) -> None:
     file.write(data)
 
 
-def generate_install_helper(file: TextIO, vendor: str, layer: str) -> None:
+def generate_install_manifest(file: TextIO, vendor: str, layer: str) -> None:
     '''
-    Generate the Android installer helper with placeholders replaced.
+    Generate the layer manifest with placeholders replaced.
 
     Args:
         file: The file handle to write to.
         vendor: The layer vendor tag.
         layer: The name of the layer.
     '''
-    data = load_template('android_install.json')
+    data = load_template('manifest.json')
     data = data.replace('{LAYER_NAME}', layer)
 
     name = get_layer_api_name(vendor, layer)
@@ -230,7 +230,7 @@ def main() -> int:
 
     outfile = os.path.join(outdir, 'android_install.json')
     with open(outfile, 'w', encoding='utf-8', newline='\n') as handle:
-        generate_install_helper(handle, args.vendor_name, args.layer_name)
+        generate_install_manifest(handle, args.vendor_name, args.layer_name)
 
     return 0
 

--- a/generator/vk_codegen/android_install.json
+++ b/generator/vk_codegen/android_install.json
@@ -1,4 +1,0 @@
-{
-    "layer_name": "{LGL_LAYER_NAME}",
-    "layer_binary": "lib{LAYER_NAME}.so"
-}

--- a/generator/vk_codegen/manifest.json
+++ b/generator/vk_codegen/manifest.json
@@ -1,0 +1,11 @@
+{
+  "file_format_version": "1.0.0",
+  "layer": {
+      "name": "{LGL_LAYER_NAME}",
+      "type": "INSTANCE",
+      "library_path": "lib{LAYER_NAME}.so",
+      "api_version": "1.0.0",
+      "implementation_version": "1",
+      "description": "Layer for ..."
+  }
+}

--- a/layer_gpu_support/android_install.json
+++ b/layer_gpu_support/android_install.json
@@ -1,5 +1,0 @@
-{
-    "layer_name": "VK_LAYER_LGL_GPUSUPPORT",
-    "layer_binary": "libVkLayerGPUSupport.so",
-    "has_config": true
-}

--- a/layer_gpu_support/manifest.json
+++ b/layer_gpu_support/manifest.json
@@ -1,0 +1,11 @@
+{
+  "file_format_version": "1.0.0",
+  "layer": {
+      "name": "VK_LAYER_LGL_GPUSUPPORT",
+      "type": "INSTANCE",
+      "library_path": "libVkLayerGPUSupport.so",
+      "api_version": "1.0.0",
+      "implementation_version": "1",
+      "description": "Layer for quick triage experimentation"
+  }
+}

--- a/layer_gpu_timeline/android_install.json
+++ b/layer_gpu_timeline/android_install.json
@@ -1,4 +1,0 @@
-{
-    "layer_name": "VK_LAYER_LGL_GPUTIMELINE",
-    "layer_binary": "libVkLayerGPUTimeline.so"
-}

--- a/layer_gpu_timeline/manifest.json
+++ b/layer_gpu_timeline/manifest.json
@@ -1,0 +1,11 @@
+{
+  "file_format_version": "1.0.0",
+  "layer": {
+      "name": "VK_LAYER_LGL_GPUTIMELINE",
+      "type": "INSTANCE",
+      "library_path": "libVkLayerGPUTimeline.so",
+      "api_version": "1.0.0",
+      "implementation_version": "1",
+      "description": "Layer for generating API correlated semantic metadata"
+  }
+}

--- a/layer_khronos_validation/android_install.json
+++ b/layer_khronos_validation/android_install.json
@@ -1,4 +1,0 @@
-{
-    "layer_name": "VK_LAYER_KHRONOS_validation",
-    "layer_binary": "libVkLayer_khronos_validation.so"
-}

--- a/layer_khronos_validation/manifest.json
+++ b/layer_khronos_validation/manifest.json
@@ -1,0 +1,11 @@
+{
+  "file_format_version": "1.0.0",
+  "layer": {
+      "name": "VK_LAYER_KHRONOS_validation",
+      "type": "INSTANCE",
+      "library_path": "libVkLayer_khronos_validation.so",
+      "api_version": "1.0.0",
+      "implementation_version": "1",
+      "description": "Layer for Vulkan API validation"
+  }
+}

--- a/lgl_android_install.py
+++ b/lgl_android_install.py
@@ -63,7 +63,7 @@ Layers will be loaded by the Vulkan loader in the order that they are specified
 on the command line, with the first layer specified being the top of the stack
 closest to the application.
 
-An android_install.json file in the layer directory informs the script of the
+The manifest.json file in the layer directory informs the script of the
 layer string identifier and shared object library name. Layers without this
 file cannot be installed using this script.
 
@@ -91,9 +91,8 @@ Layer configuration
 ===================
 
 Some layers use JSON configuration files to parameterize their behavior. If
-the android_install.json configuration file for a layer specifies that it
-requires a configuration file, this script will default to using the built-in
-layer_config.json found in the layer directory.
+a layer_config.json is found in the layer directory, the script will use this
+file by default.
 
 Users can override this, providing a custom configuration using the --config
 command line option to specify an alternative.
@@ -103,7 +102,7 @@ Khronos validation layers
 
 This installer can be used to install the Khronos validation layers. A dummy
 layer directory, layer_khronos_validation, is provided for this purpose with a
-pre-populated android_install.json config file.
+pre-populated manifest.json config file.
 
 Download the latest Khronos validation layer binaries from GitHub, and copy the
 required Arm binaries into the appropriate build directory as described in the
@@ -331,20 +330,22 @@ def get_layer_metadata(
 
     for layer_dir in layer_dirs:
         # Parse the JSON metadata file
-        metadata_path = os.path.join(layer_dir, 'android_install.json')
+        metadata_path = os.path.join(layer_dir, 'manifest.json')
+        config_path = os.path.join(layer_dir, 'layer_config.json')
+
         if not os.path.isfile(metadata_path):
-            print(f'ERROR: {layer_dir} has no android_install.json')
+            print(f'ERROR: {layer_dir} has no manifest.json')
             return None
 
         with open(metadata_path, 'r', encoding='utf-8') as handle:
             config = json.load(handle)
 
         try:
-            layer_name = config['layer_name']
-            layer_binary = config['layer_binary']
-            has_config = config.get('has_config', False)
+            layer_name = config['layer']['name']
+            layer_binary = config['layer']['library_path']
+            has_config = os.path.isfile(config_path)
         except KeyError:
-            print(f'ERROR: {layer_dir} has invalid android_install.json')
+            print(f'ERROR: {layer_dir} has invalid manifest.json')
             return None
 
         # Check that the binary exists


### PR DESCRIPTION
This PR switches to using standard Vulkan layer manifest.json files for 
configuring the Android installer, allowing the same manifest to be used
for both Android and Linux.

Fixes #77.