### PR TITLE
Intercept vkCmdEndRenderPass2[KHR]() calls

### DIFF
--- a/layer_gpu_timeline/source/layer_device_functions.hpp
+++ b/layer_gpu_timeline/source/layer_device_functions.hpp
@@ -145,7 +145,8 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderPass<user_tag>(VkCommandBuffer co
 template<>
 VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderPass2<user_tag>(VkCommandBuffer commandBuffer,
                                                                const VkSubpassEndInfo* pSubpassEndInfo);
-/* See Vulkan API for documentation. */
+
+                                                               /* See Vulkan API for documentation. */
 template<>
 VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderPass2KHR<user_tag>(VkCommandBuffer commandBuffer,
                                                                   const VkSubpassEndInfo* pSubpassEndInfo);

--- a/layer_gpu_timeline/source/layer_device_functions.hpp
+++ b/layer_gpu_timeline/source/layer_device_functions.hpp
@@ -143,6 +143,15 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderPass<user_tag>(VkCommandBuffer co
 
 /* See Vulkan API for documentation. */
 template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderPass2<user_tag>(VkCommandBuffer commandBuffer,
+                                                               const VkSubpassEndInfo* pSubpassEndInfo);
+/* See Vulkan API for documentation. */
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderPass2KHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                  const VkSubpassEndInfo* pSubpassEndInfo);
+
+/* See Vulkan API for documentation. */
+template<>
 VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRendering<user_tag>(VkCommandBuffer commandBuffer);
 
 /* See Vulkan API for documentation. */

--- a/layer_gpu_timeline/source/layer_device_functions_render_pass.cpp
+++ b/layer_gpu_timeline/source/layer_device_functions_render_pass.cpp
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: MIT
  * ----------------------------------------------------------------------------
- * Copyright (c) 2024 Arm Limited
+ * Copyright (c) 2024-2025 Arm Limited
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to

--- a/layer_gpu_timeline/source/layer_device_functions_render_pass.cpp
+++ b/layer_gpu_timeline/source/layer_device_functions_render_pass.cpp
@@ -314,6 +314,40 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderPass<user_tag>(VkCommandBuffer co
 
 /* See Vulkan API for documentation. */
 template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderPass2<user_tag>(VkCommandBuffer commandBuffer,
+                                                               const VkSubpassEndInfo* pSubpassEndInfo)
+{
+    LAYER_TRACE(__func__);
+
+    // Hold the lock to access layer-wide global store
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
+    auto* layer = Device::retrieve(commandBuffer);
+
+    // Release the lock to call into the driver
+    lock.unlock();
+    layer->driver.vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo);
+    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+}
+
+/* See Vulkan API for documentation. */
+template<>
+VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderPass2KHR<user_tag>(VkCommandBuffer commandBuffer,
+                                                                  const VkSubpassEndInfo* pSubpassEndInfo)
+{
+    LAYER_TRACE(__func__);
+
+    // Hold the lock to access layer-wide global store
+    std::unique_lock<std::mutex> lock {g_vulkanLock};
+    auto* layer = Device::retrieve(commandBuffer);
+
+    // Release the lock to call into the driver
+    lock.unlock();
+    layer->driver.vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo);
+    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+}
+
+/* See Vulkan API for documentation. */
+template<>
 VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRendering<user_tag>(VkCommandBuffer commandBuffer)
 {
     LAYER_TRACE(__func__);


### PR DESCRIPTION
Add missing function intercepts for vkCmdEndRenderPass2() 
and  vkCmdEndRenderPass2KHR().

Fixes #94