### PR TITLE
Extend Android installer support

### DIFF
--- a/docs/running_android.md
+++ b/docs/running_android.md
@@ -39,12 +39,13 @@ application after the layers are configured and stop the application when you
 finish profiling.
 
 Auto-start will default to using the main launchable activity for the package,
-but you can override this using `--package-activity` to specify the name of another activity to launch.
+but you can override this using `--package-activity` to specify the name of
+another activity to launch.
 
-You can additional pass in additional activity command line arguments by
-using the `--package-arguments` option to specify the argument string to pass
-to `am start`. This string will often contain spaces, so ensure that is
-quoted correctly on the host shell. For example:
+You can pass in additional activity command line arguments by using the
+`--package-arguments` option to specify the argument string to pass to
+`am start`. This string will often contain spaces, so ensure that is quoted
+correctly on the host shell. For example:
 
 ```sh
 ... --package-arguments "-e cmd 'R.InternalRenderScaling 0.5'"

--- a/docs/running_android.md
+++ b/docs/running_android.md
@@ -28,6 +28,28 @@ when this has been done. You can now perform your development work. When you
 are finished, return to the script and press a key to notify it that it can
 clean up the device and remove the layers.
 
+### Package launch and configuration
+
+By default, the installer will configure the layer but will not launch the
+Android package. You must manually restart the package after the layers are
+installed to ensure that they get loaded.
+
+If you specify `--auto-start`, the installer will automatically start the
+application after the layers are configured and stop the application when you
+finish profiling.
+
+Auto-start will default to using the main launchable activity for the package,
+but you can override this using `--package-activity` to specify the name of another activity to launch.
+
+You can additional pass in additional activity command line arguments by
+using the `--package-arguments` option to specify the argument string to pass
+to `am start`. This string will often contain spaces, so ensure that is
+quoted correctly on the host shell. For example:
+
+```sh
+... --package-arguments "-e cmd 'R.InternalRenderScaling 0.5'"
+```
+
 ### Layer configuration
 
 Some layers require a configuration file to control their behavior. Most
@@ -69,17 +91,6 @@ During development it is often useful to capture the Android log, using
 If you specify the `--logcat <file>` option the script will automatically clear
 the logcat log after installing the layers, and start recording logcat to the
 specified file. Logcat recording will end during device clean up.
-
-### Capturing Android Perfetto traces
-
-The Timeline layer is designed to provide semantic metadata that can be used
-to annotate an Android Perfetto render stages trace. This provides profiling
-tools with API information that Perfetto alone cannot provide, making it a
-much more data-rich visualization .
-
-If you specify the `--perfetto <file>` option the script will automatically
-configure Perfetto to capture render stages information for the target
-application and save it to the specified file.
 
 ## Manual configuration
 

--- a/layer_gpu_timeline/README_LAYER.md
+++ b/layer_gpu_timeline/README_LAYER.md
@@ -66,12 +66,17 @@ directory. Run the following script to install the layer and auto-start
 the application under test:
 
 ```sh
-python3 lgl_android_install.py --layer layer_gpu_timeline --timeline-perfetto <out.perfetto> --timeline-metadata <out.metadata> --auto-start
+python3 lgl_android_install.py --layer layer_gpu_timeline --timeline <out> --auto-start
 ```
 
 When the test has finished, press any key in the terminal to prompt the script
 to remove the layer from the device and save the data files to the specified
 host paths.
+
+The timeline data files will be saved as `<out>.perfetto` and `<out>.metadata`.
+If you want to use different file names for each, you can alternatively specify
+a full file path for each file using `--timeline-perfetto` and
+`--timeline-metadata`.
 
 ## Timeline visualization
 

--- a/lgl_android_install.py
+++ b/lgl_android_install.py
@@ -722,12 +722,12 @@ def cleanup_perfetto(
         print('ERROR: Cannot disable Perfetto recording')
 
 
-def parse_cli() -> argparse.Namespace:
+def parse_cli() -> Optional[argparse.Namespace]:
     '''
     Parse the command line.
 
     Returns:
-        An argparse results object.
+        An argparse results object, or None on error.
     '''
     parser = argparse.ArgumentParser()
 

--- a/lgl_android_install.py
+++ b/lgl_android_install.py
@@ -740,6 +740,14 @@ def parse_cli() -> argparse.Namespace:
         help='target package name or regex pattern (default=auto-detected)')
 
     parser.add_argument(
+        '--package-activity', default=None,
+        help='target package activity (optional, default=auto-detected)')
+
+    parser.add_argument(
+        '--package-arguments', default=None,
+        help='target package arguments (optional, default=None)')
+
+    parser.add_argument(
         '--layer', '-L', action='append', required=True,
         help='layer directory of a layer to install (required, repeatable)')
 
@@ -757,17 +765,45 @@ def parse_cli() -> argparse.Namespace:
 
     parser.add_argument(
         '--logcat', type=str, default=None,
-        help='save logcat to this file during the run')
+        help='save logcat to this file')
+
+    parser.add_argument(
+        '--timeline', type=str, default=None,
+        help='save Timeline traces to files with this base name')
 
     parser.add_argument(
         '--timeline-metadata', type=str, default=None,
-        help='save Timeline metadata trace to this file during the run')
+        help='save Timeline metadata trace to this file')
 
     parser.add_argument(
         '--timeline-perfetto', type=str, default=None,
-        help='save Timeline Perfetto trace to this file during the run')
+        help='save Timeline Perfetto trace to this file')
 
-    return parser.parse_args()
+    args = parser.parse_args()
+
+    # Validate arguments
+    if args.timeline and args.timeline_metadata:
+        print('ERROR: Cannot use --timeline with --timeline-metadata')
+        return None
+
+    if args.timeline and args.timeline_perfetto:
+        print('ERROR: Cannot use --timeline with --timeline-perfetto')
+        return None
+
+    if args.package_activity and not args.auto_start:
+        print('ERROR: Cannot use --package-activity without --auto-start')
+        return None
+
+    if args.package_arguments and not args.auto_start:
+        print('ERROR: Cannot use --package-arguments without --auto-start')
+        return None
+
+    # Canonicalize variant arguments for later users
+    if args.timeline:
+        args.timeline_perfetto = f'{args.timeline}.perfetto'
+        args.timeline_metadata = f'{args.timeline}.metadata'
+
+    return args
 
 
 def main() -> int:
@@ -778,6 +814,8 @@ def main() -> int:
         The process exit code.
     '''
     args = parse_cli()
+    if not args:
+        return 11
 
     conn = ADBConnect()
 
@@ -801,11 +839,13 @@ def main() -> int:
 
     conn.set_package(package)
 
-    # Determine package main activity to launch
-    activity = AndroidUtils.get_package_main_activity(conn)
+    # Determine package main activity to launch, if user didn't specify one
+    activity = args.package_activity
     if not activity:
-        print('ERROR: Package has no identifiable main activity')
-        return 4
+        activity = AndroidUtils.get_package_main_activity(conn)
+        if not activity:
+            print('ERROR: Package has no identifiable main activity')
+            return 4
 
     # Select layers to install and their configs
     need_32bit = AndroidUtils.is_package_32bit(conn, package)
@@ -855,7 +895,7 @@ def main() -> int:
 
     # Restart the package if requested
     if args.auto_start:
-        AndroidUtils.start_package(conn, activity)
+        AndroidUtils.start_package(conn, activity, args.package_arguments)
 
     input('Press any key when finished to uninstall all layers')
 

--- a/lglpy/android/utils.py
+++ b/lglpy/android/utils.py
@@ -38,7 +38,7 @@ from .adb import ADBConnect
 
 
 @contextlib.contextmanager
-def NamedTempFile(suffix=None):  # pylint: disable=invalid-name
+def NamedTempFile(suffix: str=None):  # pylint: disable=invalid-name
     '''
     Creates a context managed temporary file that can be used with external
     subprocess.
@@ -320,13 +320,15 @@ class AndroidUtils:
             return None
 
     @staticmethod
-    def start_package(conn: ADBConnect, activity: str) -> bool:
+    def start_package(conn: ADBConnect, activity: str,
+                      args: Optional[str]=None) -> bool:
         '''
         Start the package for this connection.
 
         Args:
             conn: The adb connection.
             activity: The name of the activity.
+            args: The optional command line arguments to pass
 
         Returns:
             True on success, False otherwise.
@@ -336,7 +338,11 @@ class AndroidUtils:
 
         try:
             target = f'{conn.package}/{activity}'
-            conn.adb_run('am', 'start', '-n', target, quote=True)
+            if args is None:
+                conn.adb_run('am', 'start', '-n', target, quote=True)
+            else:
+                args = shlex.split(args)
+                conn.adb_run('am', 'start', '-n', target, *args, quote=True)
         except sp.CalledProcessError:
             return False
 

--- a/lglpy/android/utils.py
+++ b/lglpy/android/utils.py
@@ -38,7 +38,7 @@ from .adb import ADBConnect
 
 
 @contextlib.contextmanager
-def NamedTempFile(suffix: str=None):  # pylint: disable=invalid-name
+def NamedTempFile(suffix: Optional[str] = None):  # pylint: disable=invalid-name
     '''
     Creates a context managed temporary file that can be used with external
     subprocess.
@@ -321,7 +321,7 @@ class AndroidUtils:
 
     @staticmethod
     def start_package(conn: ADBConnect, activity: str,
-                      args: Optional[str]=None) -> bool:
+                      args: Optional[str] = None) -> bool:
         '''
         Start the package for this connection.
 
@@ -341,8 +341,8 @@ class AndroidUtils:
             if args is None:
                 conn.adb_run('am', 'start', '-n', target, quote=True)
             else:
-                args = shlex.split(args)
-                conn.adb_run('am', 'start', '-n', target, *args, quote=True)
+                sargs = shlex.split(args)
+                conn.adb_run('am', 'start', '-n', target, *sargs, quote=True)
         except sp.CalledProcessError:
             return False
 


### PR DESCRIPTION
This PR extends the capabilities of the Android installer.

An alternative package activity can be specified using --package-activity.
Additional package command line options can be specified using --package-arguments.
Timeline capture can now use a single --timeline <out> to specify a base name used for 
both Perfetto and timeline data files.

Fixes #93 