### PR TITLE
Update minimum CMake to 3.19

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 # SOFTWARE.
 # -----------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.19)
 
 set(CMAKE_CXX_STANDARD 20)
 

--- a/generator/vk_codegen/root_CMakeLists.txt
+++ b/generator/vk_codegen/root_CMakeLists.txt
@@ -21,7 +21,7 @@
 # SOFTWARE.
 # -----------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.19)
 
 set(CMAKE_CXX_STANDARD 20)
 

--- a/layer_example/CMakeLists.txt
+++ b/layer_example/CMakeLists.txt
@@ -21,7 +21,7 @@
 # SOFTWARE.
 # -----------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.19)
 
 set(CMAKE_CXX_STANDARD 20)
 

--- a/layer_gpu_support/CMakeLists.txt
+++ b/layer_gpu_support/CMakeLists.txt
@@ -21,7 +21,7 @@
 # SOFTWARE.
 # -----------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.19)
 
 set(CMAKE_CXX_STANDARD 20)
 

--- a/layer_gpu_timeline/CMakeLists.txt
+++ b/layer_gpu_timeline/CMakeLists.txt
@@ -21,7 +21,7 @@
 # SOFTWARE.
 # -----------------------------------------------------------------------------
 
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.19)
 
 set(CMAKE_CXX_STANDARD 20)
 


### PR DESCRIPTION
Updates CMake minimum version to 3.19 to support REAL_PATH.

Fixes #100.