### PR TITLE
Timeline: Increase viewer font size

### DIFF
--- a/lglpy/timeline/gui/resources/dark.css
+++ b/lglpy/timeline/gui/resources/dark.css
@@ -1,7 +1,7 @@
 /* Centralized settings. */
 mtv-core {
 	fill-color: #262626;
-	font-size: 11;
+	font-size: 14;
 }
 
 /* ------------------------------------------------------------------------- */
@@ -9,7 +9,7 @@ mtv-core {
 
 [mtv-core] homev-core {
 	font-color: #b0b0b0;
-	font-size: 13;
+	font-size: 14;
 }
 
 /* ------------------------------------------------------------------------- */

--- a/lglpy/timeline/gui/resources/light.css
+++ b/lglpy/timeline/gui/resources/light.css
@@ -1,7 +1,7 @@
 /* Centralized settings. */
 mtv-core {
 	fill-color: #e5e5e5;
-	font-size: 11;
+	font-size: 14;
 }
 
 /* ------------------------------------------------------------------------- */
@@ -9,7 +9,7 @@ mtv-core {
 
 [mtv-core] homev-core {
 	font-color: #404040;
-	font-size: 13;
+	font-size: 14;
 }
 
 /* ------------------------------------------------------------------------- */

--- a/lglpy/timeline/gui/timeline/view.py
+++ b/lglpy/timeline/gui/timeline/view.py
@@ -74,7 +74,7 @@ class TLSpec:
     same screen space.
     '''
     CHANNEL_START_Y = 55
-    CHANNEL_BOX_Y = 40
+    CHANNEL_BOX_Y = 50
     CHANNEL_GAP_Y = 30
 
     specMap = {}  # type: dict[str, TLSpec]


### PR DESCRIPTION
The timeline font size is very small, and we have vertical space available. 
Increase the font size and the channel height to make better use of space.