### PR TITLE
Timeline: Handle missing DebugUtils extension

### DIFF
--- a/layer_gpu_timeline/source/device.cpp
+++ b/layer_gpu_timeline/source/device.cpp
@@ -100,6 +100,17 @@ Device::Device(Instance* _instance,
 
     initDriverDeviceDispatchTable(device, nlayerGetProcAddress, driver);
 
+    // Emit a log if debug utils entry points did not load. In this scenario
+    // the layer will still be loaded and send metadata packets to the server
+    // socket, but the Perfetto data will not contain any tag labels. We will
+    // therefore be unable to cross-reference the two data streams to produce a
+    // usable visualization.
+    if (!driver.vkCmdBeginDebugUtilsLabelEXT)
+    {
+        LAYER_LOG("  - ERROR: Device does not expose VK_EXT_debug_utils");
+        LAYER_LOG("           Perfetto data will not contain cross-ref tags");
+    }
+
     // Init the shared comms module for the first device built
     if (!commsModule)
     {

--- a/layer_gpu_timeline/source/device_utils.hpp
+++ b/layer_gpu_timeline/source/device_utils.hpp
@@ -48,5 +48,24 @@
         .color = {0.0f, 0.0f, 0.0f, 0.0f},
     };
 
-    layer->driver.vkCmdBeginDebugUtilsLabelEXT(commandBuffer, &tagInfo);
+    // Function pointer may be null if driver does not expose the extension
+    if (layer->driver.vkCmdBeginDebugUtilsLabelEXT)
+    {
+        layer->driver.vkCmdBeginDebugUtilsLabelEXT(commandBuffer, &tagInfo);
+    }
 }
+
+/**
+ * @brief End a tag via a driver debug utils label.
+ *
+ * @param layer           The layer context for the device.
+ * @param commandBuffer   The command buffer we are recording.
+ */
+ [[maybe_unused]] static void emitEndTag(Device* layer, VkCommandBuffer commandBuffer)
+ {
+    // Function pointer may be null if driver does not expose the extension
+    if (layer->driver.vkCmdEndDebugUtilsLabelEXT)
+    {
+        layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    }
+ }

--- a/layer_gpu_timeline/source/layer_device_functions_dispatch.cpp
+++ b/layer_gpu_timeline/source/layer_device_functions_dispatch.cpp
@@ -76,7 +76,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatch<user_tag>(VkCommandBuffer command
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver.vkCmdDispatch(commandBuffer, groupCountX, groupCountY, groupCountZ);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -106,7 +106,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatchBase<user_tag>(VkCommandBuffer com
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver
         .vkCmdDispatchBase(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -136,7 +136,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatchBaseKHR<user_tag>(VkCommandBuffer 
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver
         .vkCmdDispatchBaseKHR(commandBuffer, baseGroupX, baseGroupY, baseGroupZ, groupCountX, groupCountY, groupCountZ);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -157,5 +157,5 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdDispatchIndirect<user_tag>(VkCommandBuffer
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver.vkCmdDispatchIndirect(commandBuffer, buffer, offset);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }

--- a/layer_gpu_timeline/source/layer_device_functions_render_pass.cpp
+++ b/layer_gpu_timeline/source/layer_device_functions_render_pass.cpp
@@ -309,7 +309,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderPass<user_tag>(VkCommandBuffer co
     // Release the lock to call into the driver
     lock.unlock();
     layer->driver.vkCmdEndRenderPass(commandBuffer);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -326,7 +326,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderPass2<user_tag>(VkCommandBuffer c
     // Release the lock to call into the driver
     lock.unlock();
     layer->driver.vkCmdEndRenderPass2(commandBuffer, pSubpassEndInfo);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -343,7 +343,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderPass2KHR<user_tag>(VkCommandBuffe
     // Release the lock to call into the driver
     lock.unlock();
     layer->driver.vkCmdEndRenderPass2KHR(commandBuffer, pSubpassEndInfo);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -366,7 +366,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRendering<user_tag>(VkCommandBuffer com
     layer->driver.vkCmdEndRendering(commandBuffer);
     if (!suspending)
     {
-        layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+        emitEndTag(layer, commandBuffer);
     }
 }
 
@@ -390,6 +390,6 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdEndRenderingKHR<user_tag>(VkCommandBuffer 
     layer->driver.vkCmdEndRenderingKHR(commandBuffer);
     if (!suspending)
     {
-        layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+        emitEndTag(layer, commandBuffer);
     }
 }

--- a/layer_gpu_timeline/source/layer_device_functions_trace_rays.cpp
+++ b/layer_gpu_timeline/source/layer_device_functions_trace_rays.cpp
@@ -105,7 +105,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdBuildAccelerationStructuresIndirectKHR<use
                                                               pIndirectDeviceAddresses,
                                                               pIndirectStrides,
                                                               ppMaxPrimitiveCounts);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -131,7 +131,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdBuildAccelerationStructuresKHR<user_tag>(
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver.vkCmdBuildAccelerationStructuresKHR(commandBuffer, infoCount, pInfos, ppBuildRangeInfos);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -151,7 +151,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdTraceRaysIndirect2KHR<user_tag>(VkCommandB
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver.vkCmdTraceRaysIndirect2KHR(commandBuffer, indirectDeviceAddress);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -181,7 +181,7 @@ VKAPI_ATTR void VKAPI_CALL
                                             pHitShaderBindingTable,
                                             pCallableShaderBindingTable,
                                             indirectDeviceAddress);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -215,5 +215,5 @@ VKAPI_ATTR void VKAPI_CALL
                                     width,
                                     height,
                                     depth);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }

--- a/layer_gpu_timeline/source/layer_device_functions_transfer.cpp
+++ b/layer_gpu_timeline/source/layer_device_functions_transfer.cpp
@@ -125,7 +125,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdFillBuffer<user_tag>(VkCommandBuffer comma
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver.vkCmdFillBuffer(commandBuffer, dstBuffer, dstOffset, size, data);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -154,7 +154,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdClearColorImage<user_tag>(VkCommandBuffer 
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver.vkCmdClearColorImage(commandBuffer, image, imageLayout, pColor, rangeCount, pRanges);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -183,7 +183,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdClearDepthStencilImage<user_tag>(VkCommand
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver.vkCmdClearDepthStencilImage(commandBuffer, image, imageLayout, pDepthStencil, rangeCount, pRanges);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -214,7 +214,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer<user_tag>(VkCommandBuffer comma
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver.vkCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -242,7 +242,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer2<user_tag>(VkCommandBuffer comm
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver.vkCmdCopyBuffer2(commandBuffer, pCopyBufferInfo);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -270,7 +270,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBuffer2KHR<user_tag>(VkCommandBuffer c
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver.vkCmdCopyBuffer2KHR(commandBuffer, pCopyBufferInfo);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -305,7 +305,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyBufferToImage<user_tag>(VkCommandBuffe
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver.vkCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -337,7 +337,7 @@ VKAPI_ATTR void VKAPI_CALL
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver.vkCmdCopyBufferToImage2(commandBuffer, pCopyBufferToImageInfo);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -369,7 +369,7 @@ VKAPI_ATTR void VKAPI_CALL
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver.vkCmdCopyBufferToImage2KHR(commandBuffer, pCopyBufferToImageInfo);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -406,7 +406,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage<user_tag>(VkCommandBuffer comman
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver
         .vkCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount, pRegions);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -437,7 +437,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage2<user_tag>(VkCommandBuffer comma
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver.vkCmdCopyImage2(commandBuffer, pCopyImageInfo);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -468,7 +468,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImage2KHR<user_tag>(VkCommandBuffer co
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver.vkCmdCopyImage2KHR(commandBuffer, pCopyImageInfo);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -507,7 +507,7 @@ VKAPI_ATTR void VKAPI_CALL layer_vkCmdCopyImageToBuffer<user_tag>(VkCommandBuffe
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver.vkCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -543,7 +543,7 @@ VKAPI_ATTR void VKAPI_CALL
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver.vkCmdCopyImageToBuffer2(commandBuffer, pCopyImageToBufferInfo);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -579,7 +579,7 @@ VKAPI_ATTR void VKAPI_CALL
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver.vkCmdCopyImageToBuffer2KHR(commandBuffer, pCopyImageToBufferInfo);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -610,7 +610,7 @@ VKAPI_ATTR void VKAPI_CALL
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver.vkCmdCopyAccelerationStructureKHR(commandBuffer, pInfo);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -641,7 +641,7 @@ VKAPI_ATTR void VKAPI_CALL
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver.vkCmdCopyAccelerationStructureToMemoryKHR(commandBuffer, pInfo);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }
 
 /* See Vulkan API for documentation. */
@@ -672,5 +672,5 @@ VKAPI_ATTR void VKAPI_CALL
     lock.unlock();
     emitStartTag(layer, commandBuffer, tagID);
     layer->driver.vkCmdCopyMemoryToAccelerationStructureKHR(commandBuffer, pInfo);
-    layer->driver.vkCmdEndDebugUtilsLabelEXT(commandBuffer);
+    emitEndTag(layer, commandBuffer);
 }


### PR DESCRIPTION
The current code will crash if the device does not actually expose the debug utils 
extension. This PR makes the code defensive to this and will only call the functions
if they are available. Note that the layer will not be functional in terms of giving
a usable timeline, but it's a nicer user experience.

Fixes #108 