### PR TITLE
CMake: Remove DEPENDS from add_custom_command()

### DIFF
--- a/generator/vk_codegen/source_CMakeLists.txt
+++ b/generator/vk_codegen/source_CMakeLists.txt
@@ -65,7 +65,6 @@ target_link_libraries(
 if (CMAKE_BUILD_TYPE STREQUAL "Release")
     add_custom_command(
         TARGET "${VK_LAYER}" POST_BUILD
-        DEPENDS "${VK_LAYER}"
         COMMAND ${CMAKE_STRIP}
         ARGS --strip-all -o ${VK_LAYER_STRIP} $<TARGET_FILE:${VK_LAYER}>
         COMMENT "Stripped lib${VK_LAYER}.so to ${VK_LAYER_STRIP}")

--- a/layer_example/source/CMakeLists.txt
+++ b/layer_example/source/CMakeLists.txt
@@ -66,7 +66,6 @@ target_link_libraries(
 if (CMAKE_BUILD_TYPE STREQUAL "Release")
     add_custom_command(
         TARGET "${VK_LAYER}" POST_BUILD
-        DEPENDS "${VK_LAYER}"
         COMMAND ${CMAKE_STRIP}
         ARGS --strip-all -o ${VK_LAYER_STRIP} $<TARGET_FILE:${VK_LAYER}>
         COMMENT "Stripped lib${VK_LAYER}.so to ${VK_LAYER_STRIP}")

--- a/layer_gpu_support/source/CMakeLists.txt
+++ b/layer_gpu_support/source/CMakeLists.txt
@@ -74,7 +74,6 @@ target_link_libraries(
 if (CMAKE_BUILD_TYPE STREQUAL "Release")
     add_custom_command(
         TARGET "${VK_LAYER}" POST_BUILD
-        DEPENDS "${VK_LAYER}"
         COMMAND ${CMAKE_STRIP}
         ARGS --strip-all -o ${VK_LAYER_STRIP} $<TARGET_FILE:${VK_LAYER}>
         COMMENT "Stripped lib${VK_LAYER}.so to ${VK_LAYER_STRIP}")

--- a/layer_gpu_timeline/source/CMakeLists.txt
+++ b/layer_gpu_timeline/source/CMakeLists.txt
@@ -81,7 +81,6 @@ target_link_libraries(
 if (CMAKE_BUILD_TYPE STREQUAL "Release")
     add_custom_command(
         TARGET "${VK_LAYER}" POST_BUILD
-        DEPENDS "${VK_LAYER}"
         COMMAND ${CMAKE_STRIP}
         ARGS --strip-all -o ${VK_LAYER_STRIP} $<TARGET_FILE:${VK_LAYER}>
         COMMENT "Stripped lib${VK_LAYER}.so to ${VK_LAYER_STRIP}")


### PR DESCRIPTION
Newer CMake reports a warning that we have an unsupported
DEPENDS argument to add_custom_command(TARGET ...).
Remove it, as it's not needed.