### PR TITLE
Fix event skipping in the timeline viewer

### DIFF
--- a/lglpy/timeline/data/processed_trace.py
+++ b/lglpy/timeline/data/processed_trace.py
@@ -77,7 +77,7 @@ class GPUWorkload:
         # Common data we get from the layer metadata
         self.submit = None
         self.label_stack = None
-        self.parsed_label_name = None
+        self.parsed_label_name: Optional[str] = None
 
         if metadata:
             self.submit = metadata.submit


### PR DESCRIPTION
Ensure that we use the physical stream name rather than the Perfetto interned ID when doing stream manipulation, as the Perfetto interned ID may not be unique.