### PR TITLE
Framework: Support vkGetInstanceProcAddr for global functions

### DIFF
--- a/source_common/framework/manual_functions.cpp
+++ b/source_common/framework/manual_functions.cpp
@@ -113,11 +113,14 @@ VkLayerDeviceCreateInfo* getChainInfo(const VkDeviceCreateInfo* pCreateInfo)
 /* See header for documentation. */
 std::pair<bool, PFN_vkVoidFunction> getInstanceLayerFunction(const char* name)
 {
-    const std::array<const char*, 4> globalFunctions {
+    const std::array<const char*, 5> globalFunctions {
+        // Supported since Vulkan 1.0
         "vkCreateInstance",
         "vkEnumerateInstanceVersion",
         "vkEnumerateInstanceExtensionProperties",
-        "vkEnumerateInstanceLayerProperties"
+        "vkEnumerateInstanceLayerProperties",
+        // Supported since Vulkan 1.2
+        "vkGetInstanceProcAddr",
     };
 
     bool isGlobal {false};

--- a/source_common/framework/manual_functions.cpp
+++ b/source_common/framework/manual_functions.cpp
@@ -116,9 +116,10 @@ std::pair<bool, PFN_vkVoidFunction> getInstanceLayerFunction(const char* name)
     const std::array<const char*, 5> globalFunctions {
         // Supported since Vulkan 1.0
         "vkCreateInstance",
-        "vkEnumerateInstanceVersion",
         "vkEnumerateInstanceExtensionProperties",
         "vkEnumerateInstanceLayerProperties",
+        // Supported since Vulkan 1.1
+        "vkEnumerateInstanceVersion",
         // Supported since Vulkan 1.2
         "vkGetInstanceProcAddr",
     };
@@ -167,12 +168,14 @@ APIVersion getInstanceAPIVersion(PFN_vkGetInstanceProcAddr fpGetProcAddr)
     return { 1, 3 };
 #endif
 
+    // Try to get vkEnumerateInstanceVersion, and assume this is a Vulkan 1.0
+    // feature level if we don't get it ...
     auto fpFunctionRaw = fpGetProcAddr(nullptr, "vkEnumerateInstanceVersion");
     auto fpFunction = reinterpret_cast<PFN_vkEnumerateInstanceVersion>(fpFunctionRaw);
     if (!fpFunction)
     {
-        LAYER_ERR("Failed to get vkEnumerateInstanceVersion()");
-        return {0, 0};
+        LAYER_ERR("Failed to get vkEnumerateInstanceVersion(), assuming Vulkan 1.0");
+        return {1, 0};
     }
 
     uint32_t apiVersion = 0;

--- a/source_common/framework/manual_functions.hpp
+++ b/source_common/framework/manual_functions.hpp
@@ -44,6 +44,7 @@
 #include <mutex>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 /**
@@ -85,10 +86,11 @@ PFN_vkVoidFunction getFixedInstanceLayerFunction(const char* name);
  *
  * @param name   The Vulkan function name.
  *
- * @return The layer function pointer, or \c nullptr if the layer doesn't
+ * @return Boolean indicating if this is a globally accessible function, and
+ *         the layer function pointer, or \c nullptr if the layer doesn't
  *         intercept the function.
  */
-PFN_vkVoidFunction getInstanceLayerFunction(const char* name);
+std::pair<bool, PFN_vkVoidFunction> getInstanceLayerFunction(const char* name);
 
 /**
  * @brief Fetch the function for a given dynamic instance entrypoint name.


### PR DESCRIPTION
The Android loader resolves all global functions using dlsym, but the 
full desktop loader tries to load them by using vkGetInstanceProcAddr
with an invalid instance pointer (because the instance doesn't exist yet).

This PR allows global functions to return without needing a valid instance.