### PR TITLE
Defer destroy

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -80,6 +80,15 @@ jobs:
           cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..
           make -j4
 
+      - name: Build layer_gpu_profile
+        run: |
+          export CC=clang
+          export CXX=clang++
+          mkdir layer_gpu_profile/build_rel
+          cd layer_gpu_profile/build_rel
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..
+          make -j4
+
       - name: Build and run unit tests
         run: |
           export CC=clang
@@ -126,6 +135,15 @@ jobs:
           cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..
           make -j4
 
+      - name: Build layer_gpu_profile
+        run: |
+          export CC=gcc
+          export CXX=g++
+          mkdir layer_gpu_profile/build_rel
+          cd layer_gpu_profile/build_rel
+          cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..
+          make -j4
+
   build-android:
     name: Android
     runs-on: ubuntu-22.04
@@ -148,6 +166,11 @@ jobs:
       - name: Build layer_gpu_timeline
         run: |
           cd layer_gpu_timeline
+          bash ./android_build.sh Release
+
+      - name: Build layer_gpu_profile
+        run: |
+          cd layer_gpu_profile
           bash ./android_build.sh Release
 
   build-ubuntu-x64-clang-new-common:

--- a/generator/vk_layer/source/device.cpp
+++ b/generator/vk_layer/source/device.cpp
@@ -79,10 +79,15 @@ Device* Device::retrieve(
 }
 
 /* See header for documentation. */
-void Device::destroy(
-    Device* device
+std::unique_ptr<Device> Device::destroy(
+    VkDevice handle
 ) {
-    g_devices.erase(getDispatchKey(device));
+    void* key = getDispatchKey(handle);
+    assert(isInMap(key, g_devices));
+
+    auto device = std::move(g_devices.at(key));
+    g_devices.erase(key);
+    return device;
 }
 
 /* See header for documentation. */

--- a/generator/vk_layer/source/device.hpp
+++ b/generator/vk_layer/source/device.hpp
@@ -115,12 +115,17 @@ public:
         VkCommandBuffer handle);
 
     /**
-     * @brief Drop a device from the global store of dispatchable devices.
+     * \brief Drop a device from the global store of dispatchable devices.
      *
-     * @param device   The device to drop.
+     * This must be called before the driver VkDevice has been destroyed, as
+     * we deference the native device handle to get the dispatch key.
+     *
+     * \param handle   The dispatchable device handle to use as an indirect lookup.
+     *
+     * \return Returns the ownership of the Device object to the caller.
      */
-    static void destroy(
-        Device* device);
+    static std::unique_ptr<Device> destroy(
+        VkDevice handle);
 
     /**
      * @brief Create a new layer device object.

--- a/generator/vk_layer/source/instance.cpp
+++ b/generator/vk_layer/source/instance.cpp
@@ -70,10 +70,15 @@ Instance* Instance::retrieve(
 }
 
 /* See header for documentation. */
-void Instance::destroy(
-    Instance* instance
+std::unique_ptr<Instance> Instance::destroy(
+    VkInstance handle
 ) {
-    g_instances.erase(getDispatchKey(instance->instance));
+    void* key = getDispatchKey(handle);
+    assert(isInMap(key, g_instances));
+
+    auto instance = std::move(g_instances.at(key));
+    g_instances.erase(key);
+    return instance;
 }
 
 /* See header for documentation. */

--- a/generator/vk_layer/source/instance.hpp
+++ b/generator/vk_layer/source/instance.hpp
@@ -99,12 +99,17 @@ public:
         VkPhysicalDevice handle);
 
     /**
-     * @brief Drop an instance from the global store of dispatchable instances.
+     * \brief Drop an instance from the global store of dispatchable instances.
      *
-     * @param instance   The instance to drop.
+     * This must be called before the driver VkInstance has been destroyed, as
+     * we deference the native instance handle to get the dispatch key.
+     *
+     * \param handle   The dispatchable instance handle to use as an indirect lookup.
+     *
+     * \return Returns the ownership of the Instance object to the caller.
      */
-    static void destroy(
-        Instance* instance);
+    static std::unique_ptr<Instance> destroy(
+        VkInstance handle);
 
     /**
      * @brief Create a new layer instance object.

--- a/layer_example/source/device.cpp
+++ b/layer_example/source/device.cpp
@@ -75,9 +75,15 @@ Device* Device::retrieve(VkCommandBuffer handle)
 }
 
 /* See header for documentation. */
-void Device::destroy(Device* device)
-{
-    g_devices.erase(getDispatchKey(device));
+std::unique_ptr<Device> Device::destroy(
+    VkDevice handle
+) {
+    void* key = getDispatchKey(handle);
+    assert(isInMap(key, g_devices));
+
+    auto device = std::move(g_devices.at(key));
+    g_devices.erase(key);
+    return device;
 }
 
 /* See header for documentation. */

--- a/layer_example/source/device.hpp
+++ b/layer_example/source/device.hpp
@@ -110,11 +110,17 @@ public:
     static Device* retrieve(VkCommandBuffer handle);
 
     /**
-     * @brief Drop a device from the global store of dispatchable devices.
+     * \brief Drop a device from the global store of dispatchable devices.
      *
-     * @param device   The device to drop.
+     * This must be called before the driver VkDevice has been destroyed, as
+     * we deference the native device handle to get the dispatch key.
+     *
+     * \param handle   The dispatchable device handle to use as an indirect lookup.
+     *
+     * \return Returns the ownership of the Device object to the caller.
      */
-    static void destroy(Device* device);
+    static std::unique_ptr<Device> destroy(
+        VkDevice handle);
 
     /**
      * @brief Create a new layer device object.

--- a/layer_example/source/instance.cpp
+++ b/layer_example/source/instance.cpp
@@ -64,9 +64,15 @@ Instance* Instance::retrieve(VkPhysicalDevice handle)
 }
 
 /* See header for documentation. */
-void Instance::destroy(Instance* instance)
-{
-    g_instances.erase(getDispatchKey(instance->instance));
+std::unique_ptr<Instance> Instance::destroy(
+    VkInstance handle
+) {
+    void* key = getDispatchKey(handle);
+    assert(isInMap(key, g_instances));
+
+    auto instance = std::move(g_instances.at(key));
+    g_instances.erase(key);
+    return instance;
 }
 
 /* See header for documentation. */

--- a/layer_example/source/instance.hpp
+++ b/layer_example/source/instance.hpp
@@ -95,11 +95,17 @@ public:
     static Instance* retrieve(VkPhysicalDevice handle);
 
     /**
-     * @brief Drop an instance from the global store of dispatchable instances.
+     * \brief Drop an instance from the global store of dispatchable instances.
      *
-     * @param instance   The instance to drop.
+     * This must be called before the driver VkInstance has been destroyed, as
+     * we deference the native instance handle to get the dispatch key.
+     *
+     * \param handle   The dispatchable instance handle to use as an indirect lookup.
+     *
+     * \return Returns the ownership of the Instance object to the caller.
      */
-    static void destroy(Instance* instance);
+    static std::unique_ptr<Instance> destroy(
+        VkInstance handle);
 
     /**
      * @brief Create a new layer instance object.

--- a/layer_gpu_profile/source/device.cpp
+++ b/layer_gpu_profile/source/device.cpp
@@ -82,9 +82,15 @@ Device* Device::retrieve(VkCommandBuffer handle)
 }
 
 /* See header for documentation. */
-void Device::destroy(Device* device)
-{
-    g_devices.erase(getDispatchKey(device));
+std::unique_ptr<Device> Device::destroy(
+    VkDevice handle
+) {
+    void* key = getDispatchKey(handle);
+    assert(isInMap(key, g_devices));
+
+    auto device = std::move(g_devices.at(key));
+    g_devices.erase(key);
+    return device;
 }
 
 /* See header for documentation. */

--- a/layer_gpu_profile/source/device.hpp
+++ b/layer_gpu_profile/source/device.hpp
@@ -118,11 +118,17 @@ public:
     static Device* retrieve(VkCommandBuffer handle);
 
     /**
-     * @brief Drop a device from the global store of dispatchable devices.
+     * \brief Drop a device from the global store of dispatchable devices.
      *
-     * @param device   The device to drop.
+     * This must be called before the driver VkDevice has been destroyed, as
+     * we deference the native device handle to get the dispatch key.
+     *
+     * \param handle   The dispatchable device handle to use as an indirect lookup.
+     *
+     * \return Returns the ownership of the Device object to the caller.
      */
-    static void destroy(Device* device);
+    static std::unique_ptr<Device> destroy(
+        VkDevice handle);
 
     /**
      * @brief Create a new layer device object.

--- a/layer_gpu_profile/source/instance.cpp
+++ b/layer_gpu_profile/source/instance.cpp
@@ -66,9 +66,15 @@ Instance* Instance::retrieve(VkPhysicalDevice handle)
 }
 
 /* See header for documentation. */
-void Instance::destroy(Instance* instance)
-{
-    g_instances.erase(getDispatchKey(instance->instance));
+std::unique_ptr<Instance> Instance::destroy(
+    VkInstance handle
+) {
+    void* key = getDispatchKey(handle);
+    assert(isInMap(key, g_instances));
+
+    auto instance = std::move(g_instances.at(key));
+    g_instances.erase(key);
+    return instance;
 }
 
 /* See header for documentation. */

--- a/layer_gpu_profile/source/instance.hpp
+++ b/layer_gpu_profile/source/instance.hpp
@@ -96,11 +96,17 @@ public:
     static Instance* retrieve(VkPhysicalDevice handle);
 
     /**
-     * @brief Drop an instance from the global store of dispatchable instances.
+     * \brief Drop an instance from the global store of dispatchable instances.
      *
-     * @param instance   The instance to drop.
+     * This must be called before the driver VkInstance has been destroyed, as
+     * we deference the native instance handle to get the dispatch key.
+     *
+     * \param handle   The dispatchable instance handle to use as an indirect lookup.
+     *
+     * \return Returns the ownership of the Instance object to the caller.
      */
-    static void destroy(Instance* instance);
+    static std::unique_ptr<Instance> destroy(
+        VkInstance handle);
 
     /**
      * @brief Create a new layer instance object.

--- a/layer_gpu_support/source/device.cpp
+++ b/layer_gpu_support/source/device.cpp
@@ -80,9 +80,15 @@ Device* Device::retrieve(VkCommandBuffer handle)
 }
 
 /* See header for documentation. */
-void Device::destroy(Device* device)
-{
-    g_devices.erase(getDispatchKey(device));
+std::unique_ptr<Device> Device::destroy(
+    VkDevice handle
+) {
+    void* key = getDispatchKey(handle);
+    assert(isInMap(key, g_devices));
+
+    auto device = std::move(g_devices.at(key));
+    g_devices.erase(key);
+    return device;
 }
 
 /* See header for documentation. */

--- a/layer_gpu_support/source/device.hpp
+++ b/layer_gpu_support/source/device.hpp
@@ -111,11 +111,17 @@ public:
     static Device* retrieve(VkCommandBuffer handle);
 
     /**
-     * @brief Drop a device from the global store of dispatchable devices.
+     * \brief Drop a device from the global store of dispatchable devices.
      *
-     * @param device   The device to drop.
+     * This must be called before the driver VkDevice has been destroyed, as
+     * we deference the native device handle to get the dispatch key.
+     *
+     * \param handle   The dispatchable device handle to use as an indirect lookup.
+     *
+     * \return Returns the ownership of the Device object to the caller.
      */
-    static void destroy(Device* device);
+    static std::unique_ptr<Device> destroy(
+        VkDevice handle);
 
     /**
      * @brief Create a new layer device object.

--- a/layer_gpu_support/source/instance.cpp
+++ b/layer_gpu_support/source/instance.cpp
@@ -66,9 +66,15 @@ Instance* Instance::retrieve(VkPhysicalDevice handle)
 }
 
 /* See header for documentation. */
-void Instance::destroy(Instance* instance)
-{
-    g_instances.erase(getDispatchKey(instance->instance));
+std::unique_ptr<Instance> Instance::destroy(
+    VkInstance handle
+) {
+    void* key = getDispatchKey(handle);
+    assert(isInMap(key, g_instances));
+
+    auto instance = std::move(g_instances.at(key));
+    g_instances.erase(key);
+    return instance;
 }
 
 /* See header for documentation. */

--- a/layer_gpu_support/source/instance.hpp
+++ b/layer_gpu_support/source/instance.hpp
@@ -95,11 +95,17 @@ public:
     static Instance* retrieve(VkPhysicalDevice handle);
 
     /**
-     * @brief Drop an instance from the global store of dispatchable instances.
+     * \brief Drop an instance from the global store of dispatchable instances.
      *
-     * @param instance   The instance to drop.
+     * This must be called before the driver VkInstance has been destroyed, as
+     * we deference the native instance handle to get the dispatch key.
+     *
+     * \param handle   The dispatchable instance handle to use as an indirect lookup.
+     *
+     * \return Returns the ownership of the Instance object to the caller.
      */
-    static void destroy(Instance* instance);
+    static std::unique_ptr<Instance> destroy(
+        VkInstance handle);
 
     /**
      * @brief Create a new layer instance object.

--- a/layer_gpu_timeline/source/device.cpp
+++ b/layer_gpu_timeline/source/device.cpp
@@ -78,9 +78,15 @@ Device* Device::retrieve(VkCommandBuffer handle)
 }
 
 /* See header for documentation. */
-void Device::destroy(Device* device)
-{
-    g_devices.erase(getDispatchKey(device));
+std::unique_ptr<Device> Device::destroy(
+    VkDevice handle
+) {
+    void* key = getDispatchKey(handle);
+    assert(isInMap(key, g_devices));
+
+    auto device = std::move(g_devices.at(key));
+    g_devices.erase(key);
+    return device;
 }
 
 /* See header for documentation. */

--- a/layer_gpu_timeline/source/device.hpp
+++ b/layer_gpu_timeline/source/device.hpp
@@ -113,11 +113,17 @@ public:
     static Device* retrieve(VkCommandBuffer handle);
 
     /**
-     * @brief Drop a device from the global store of dispatchable devices.
+     * \brief Drop a device from the global store of dispatchable devices.
      *
-     * @param device   The device to drop.
+     * This must be called before the driver VkDevice has been destroyed, as
+     * we deference the native device handle to get the dispatch key.
+     *
+     * \param handle   The dispatchable device handle to use as an indirect lookup.
+     *
+     * \return Returns the ownership of the Device object to the caller.
      */
-    static void destroy(Device* device);
+    static std::unique_ptr<Device> destroy(
+        VkDevice handle);
 
     /**
      * @brief Create a new layer device object.

--- a/layer_gpu_timeline/source/instance.cpp
+++ b/layer_gpu_timeline/source/instance.cpp
@@ -66,9 +66,15 @@ Instance* Instance::retrieve(VkPhysicalDevice handle)
 }
 
 /* See header for documentation. */
-void Instance::destroy(Instance* instance)
-{
-    g_instances.erase(getDispatchKey(instance->instance));
+std::unique_ptr<Instance> Instance::destroy(
+    VkInstance handle
+) {
+    void* key = getDispatchKey(handle);
+    assert(isInMap(key, g_instances));
+
+    auto instance = std::move(g_instances.at(key));
+    g_instances.erase(key);
+    return instance;
 }
 
 /* See header for documentation. */

--- a/layer_gpu_timeline/source/instance.hpp
+++ b/layer_gpu_timeline/source/instance.hpp
@@ -95,11 +95,17 @@ public:
     static Instance* retrieve(VkPhysicalDevice handle);
 
     /**
-     * @brief Drop an instance from the global store of dispatchable instances.
+     * \brief Drop an instance from the global store of dispatchable instances.
      *
-     * @param instance   The instance to drop.
+     * This must be called before the driver VkInstance has been destroyed, as
+     * we deference the native instance handle to get the dispatch key.
+     *
+     * \param handle   The dispatchable instance handle to use as an indirect lookup.
+     *
+     * \return Returns the ownership of the Instance object to the caller.
      */
-    static void destroy(Instance* instance);
+    static std::unique_ptr<Instance> destroy(
+        VkInstance handle);
 
     /**
      * @brief Create a new layer instance object.

--- a/source_common/framework/manual_functions.cpp
+++ b/source_common/framework/manual_functions.cpp
@@ -749,17 +749,13 @@ VKAPI_ATTR void VKAPI_CALL layer_vkDestroyInstance_default(VkInstance instance, 
 
     // Hold the lock to access layer-wide global store
     std::unique_lock<std::mutex> lock {g_vulkanLock};
-    auto* layer = Instance::retrieve(instance);
 
-    // Save the driver function to avoid a use-after free when proxy is destroyed
-    auto destroyInstance = layer->driver.vkDestroyInstance;
-
-    // Layer proxy must be destroyed before the driver object as we use its dispatchable handle
-    Instance::destroy(layer);
+    // Take local ownership of the Instance before calling the driver
+    auto layer = Instance::destroy(instance);
 
     // Release the lock to call into the driver
     lock.unlock();
-    destroyInstance(instance, pAllocator);
+    layer->driver.vkDestroyInstance(instance, pAllocator);
 }
 
 /* See Vulkan API for documentation. */
@@ -839,17 +835,13 @@ VKAPI_ATTR void VKAPI_CALL layer_vkDestroyDevice_default(VkDevice device, const 
 
     // Hold the lock to access layer-wide global store
     std::unique_lock<std::mutex> lock {g_vulkanLock};
-    auto* layer = Device::retrieve(device);
 
-    // Save the driver function to avoid a use-after free when proxy is destroyed
-    auto destroyDevice = layer->driver.vkDestroyDevice;
-
-    // Layer proxy must be destroyed before the driver object as we use its dispatchable handle
-    Device::destroy(layer);
+    // Take local ownership of the Device before calling the driver
+    auto layer = Device::destroy(device);
 
     // Release the lock to call into the driver
     lock.unlock();
-    destroyDevice(device, pAllocator);
+    layer->driver.vkDestroyDevice(device, pAllocator);
 }
 
 /* See Vulkan API for documentation. */


### PR DESCRIPTION
This PR implements a more general solution to the cleanup of layer Instance and Device proxies when the native handle is destroyed. 

We need to erase the proxy from our map of known proxies before the native object is destroyed. This is because we need to dereference the native handle to get the dispatch key we use in our map, and we need to remove before calling the driver to avoid a race between dropping the old proxy and a new native object being allocated with the same handle in a different thread. 

We need to delete the proxy after the native object is destroyed because it is possible for layers using callbacks to get those callbacks during the driver deletion call. No public layer needs this today, so this is not currently a functional bug, but it's a good futureproofing change. 

The new design removes the proxy from our map on "Proxy::destroy" but moves ownership to the caller, so we now modify the map before the driver call and also keep the proxy alive until the layer function returns. 

