### PR TITLE
Add blocking wait to comms creation

### DIFF
--- a/layer_gpu_profile/source/device.cpp
+++ b/layer_gpu_profile/source/device.cpp
@@ -50,6 +50,8 @@ std::unique_ptr<Comms::CommsModule> Device::commsModule;
 /* See header for documentation. */
 std::unique_ptr<ProfileComms> Device::commsWrapper;
 
+extern std::mutex g_vulkanLock;
+
 /* See header for documentation. */
 void Device::store(VkDevice handle, std::unique_ptr<Device> device)
 {
@@ -119,10 +121,13 @@ Device::Device(Instance* _instance,
     }
 
     // Init the shared comms module for the first device built
-    if (!commsModule)
     {
-        commsModule = std::make_unique<Comms::CommsModule>("lglcomms");
-        commsWrapper = std::make_unique<ProfileComms>(*commsModule);
+        std::lock_guard<std::mutex> lock { g_vulkanLock };
+        if (!commsModule)
+        {
+            commsModule = std::make_unique<Comms::CommsModule>("lglcomms");
+            commsWrapper = std::make_unique<ProfileComms>(*commsModule);
+        }
     }
 
     // Create events for CPU<>GPU synchronization

--- a/layer_gpu_timeline/source/device.cpp
+++ b/layer_gpu_timeline/source/device.cpp
@@ -46,6 +46,8 @@ std::unique_ptr<Comms::CommsModule> Device::commsModule;
 /* See header for documentation. */
 std::unique_ptr<TimelineComms> Device::commsWrapper;
 
+extern std::mutex g_vulkanLock;
+
 /* See header for documentation. */
 void Device::store(VkDevice handle, std::unique_ptr<Device> device)
 {
@@ -115,10 +117,13 @@ Device::Device(Instance* _instance,
     }
 
     // Init the shared comms module for the first device built
-    if (!commsModule)
     {
-        commsModule = std::make_unique<Comms::CommsModule>("lglcomms");
-        commsWrapper = std::make_unique<TimelineComms>(*commsModule);
+        std::lock_guard<std::mutex> lock { g_vulkanLock };
+        if (!commsModule)
+        {
+            commsModule = std::make_unique<Comms::CommsModule>("lglcomms");
+            commsWrapper = std::make_unique<TimelineComms>(*commsModule);
+        }
     }
 
     // Determine the driver version and emit the preamble message


### PR DESCRIPTION
The current code has a racy initialization of the `VkDevice` communications module, and can crash if a second device sees a valid `commsModule` but gets a `nullptr` for `commsWrapper` which is still being built by the first context.

This change adds locking around comms creation to ensure that any device sees a completely inited comms stack. Lock is always taken for sake of simplicity - this isn't a performance critical code path.