### PR TITLE
Timeline view: Add string memoization

### DIFF
--- a/lglpy/timeline/data/processed_trace.py
+++ b/lglpy/timeline/data/processed_trace.py
@@ -61,7 +61,7 @@ class GPUWorkload:
     PARENS = re.compile(r'(\(.*\))')
     RESOLUTION = re.compile(r'\d+x\d+')
     WHITESPACE = re.compile(r'\s\s+')
-    MEMO = dict()
+    MEMO: dict[str, str] = dict()
 
     @classmethod
     def memoize(cls, string: str) -> str:

--- a/lglpy/timeline/data/raw_trace.py
+++ b/lglpy/timeline/data/raw_trace.py
@@ -300,7 +300,7 @@ class MetadataWorkload:
         label_stack: Debug label stack, or None if no user labels.
     '''
 
-    MEMO = dict()
+    MEMO: dict[str, str] = dict()
 
     @classmethod
     def memoize(cls, string: str) -> str:


### PR DESCRIPTION
The timeline data consists of a lot of repeating strings, so it is a good candidate for string memoization to reduce the amount of duplicate variable values being stored in memory. 

In local testing this PR reduces load time memory use (memoizing raw trace) by about 10%, and dynamic viewer memory footprint (memoizing processed trace) by a similar amount. 

Fixes #142 
