### PR TITLE
Disable entrypoint logging in the timeline layer

### DIFF
--- a/layer_gpu_timeline/CMakeLists.txt
+++ b/layer_gpu_timeline/CMakeLists.txt
@@ -31,7 +31,7 @@ project(VkLayerGPUTimeline VERSION 1.0.0)
 # Common configuration
 set(LGL_LOG_TAG "VkLayerGPUTimeline")
 
-option(LGL_CONFIG_TRACE "Enable Vulkan entrypoint logging" ON)
+option(LGL_CONFIG_TRACE "Enable Vulkan entrypoint logging")
 option(LGL_CONFIG_OPTIMIZE_DISPATCH "Enable Vulkan entrypoint dispatch optimization" ON)
 option(LGL_CONFIG_LOG "Enable general layer logging" ON)
 


### PR DESCRIPTION
The PR for the timeline layer entry point filtering rework left API entry point trace enabled in the default CMake config. Set it disabled by default.