### PR TITLE
Only pop a marker if we have an earlier push

### DIFF
--- a/source_common/trackers/queue.cpp
+++ b/source_common/trackers/queue.cpp
@@ -76,7 +76,12 @@ namespace
         {
             UNUSED(instruction);
 
-            queueState.debugStack.pop_back();
+            // Only pop if we have an earlier push - this shouldn't happen and
+            // is a validation violation, but not all apps handle this correctly
+            if (!queueState.debugStack.empty())
+            {
+                queueState.debugStack.pop_back();
+            }
         }
 
         /**


### PR DESCRIPTION
The current tracker will crash in `push_back()` if an app attempts to pop a marker without an earlier corresponding push. Make this defensive, to avoid popping off an empty label stack.

Fixes #150 