### PR TITLE
Use safe-struct chain info copy

### DIFF
--- a/source_common/framework/manual_functions.cpp
+++ b/source_common/framework/manual_functions.cpp
@@ -784,6 +784,10 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateInstance<default_tag>(const VkInsta
         LAYER_LOG("Requested instance extension list: [%u] = %s", i, newCreateInfo->ppEnabledExtensionNames[i]);
     }
 
+    // Get the new chain info so we modify our safe copy, not the original
+    chainInfo = getChainInfo(newCreateInfo);
+
+    // Advance the link info for the next element on the chain
     chainInfo->u.pLayerInfo = chainInfo->u.pLayerInfo->pNext;
     auto result = fpCreateInstance(newCreateInfo, pAllocator, pInstance);
     if (result != VK_SUCCESS)
@@ -873,6 +877,9 @@ VKAPI_ATTR VkResult VKAPI_CALL layer_vkCreateDevice<default_tag>(VkPhysicalDevic
     {
         return VK_ERROR_INITIALIZATION_FAILED;
     }
+
+    // Get the new chain info so we modify our safe copy, not the original
+    chainInfo = getChainInfo(newCreateInfo);
 
     // Advance the link info for the next element on the chain
     chainInfo->u.pLayerInfo = chainInfo->u.pLayerInfo->pNext;


### PR DESCRIPTION
When we refactored the code to use safe-struct to avoid const-casting in layer code we failed to change the chain info pointer, so kept modifying the original user chain info rather than modifying the the safe-struct clone. This passed all our tests because when you are using a single layer you talk directly to the driver, which doesn't use the chain info, but it fails as soon as you have multiple layers because the chain is never advanced as you call down the stack. The end result is an infinite recursion of vkCreateInstance/vkCreateDevice calls into the second layer in the stack of N layers.

Fixes #157 